### PR TITLE
fixes for h2spec tests: 5.1. Stream States

### DIFF
--- a/src/http2_stream.erl
+++ b/src/http2_stream.erl
@@ -684,6 +684,7 @@ process(send,
 %% TODO: ???
 process(Direction, Frame, {Stream, Connection}) ->
     lager:error("No process/3 for ~p, ~p, ~p", [Direction,Frame,Stream]),
+    http2_connection:go_away(?STREAM_CLOSED, Connection),
     {Stream, Connection}.
 
 


### PR DESCRIPTION
Bored and wanted to work on understanding http2 again and thought I'd try helping out by running https://github.com/summerwind/h2spec against chatterbox.

I'm not positive these are the proper fixes... but I worked on these changes to fix 5.1:

```
  5.1. Stream States
    ✓ idle: Sends a DATA frame
    ✓ idle: Sends a RST_STREAM frame
    ✓ idle: Sends a WINDOW_UPDATE frame
    ✓ idle: Sends a CONTINUATION frame
    ✓ half closed (remote): Sends a DATA frame
    ✓ half closed (remote): Sends a HEADERS frame
    ✓ half closed (remote): Sends a CONTINUATION frame
    ✓ closed: Sends a CONTINUATION frame
```