### PR TITLE
if connection on even stream from client return protocol error

### DIFF
--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -198,6 +198,11 @@ handshake({frame, {FH, _Payload}=Frame}, State) ->
             go_away(?PROTOCOL_ERROR, State)
     end.
 
+connected({frame, {#frame_header{stream_id=StreamId}, _}},
+          S = #connection_state{}
+         ) when StreamId > 1, StreamId rem 2 =:= 0 ->
+    %% But only if from the client or something?
+    go_away(?PROTOCOL_ERROR, S);
 connected({frame, Frame},
           S = #connection_state{}
          ) ->


### PR DESCRIPTION
This one I know can't be merged yet because `http2_connection:connected` is used by both client and server, correct? In which case... is there a way to know if it is client->server so it knows it has to be an odd streamid?

```
  5.1. Stream States
    5.1.1. Stream Identifiers
      ✓ Sends even-numbered stream identifier
```