### PR TITLE
I Owe Data frames a better type spec

### DIFF
--- a/include/http2.hrl
+++ b/include/http2.hrl
@@ -92,7 +92,7 @@
 -type frame_header() :: #frame_header{}.
 
 -record(data, {
-    data :: binary()
+    data :: iodata()
   }).
 -type data() :: #data{}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
   {lager, "2.2.1",
     {git, "git://github.com/basho/lager.git", {tag, "2.2.1"}}},
   {hpack, ".*",
-    {git, "git://github.com/joedevivo/hpack.git", {tag, "0.1.0"}}}
+    {git, "git://github.com/joedevivo/hpack.git", {branch, "master"}}}
  ]}.
 
 {cover_enabled, true}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
   1},
  {<<"hpack">>,
   {git,"git://github.com/joedevivo/hpack.git",
-       {ref,"10106d65b5be4236e0b437edc45f1b45a93baecf"}},
+       {ref,"a20c3cca97b4d00f208aa34621835cec1cf74948"}},
   0},
  {<<"lager">>,
   {git,"git://github.com/basho/lager.git",

--- a/src/http2_frame_data.erl
+++ b/src/http2_frame_data.erl
@@ -6,7 +6,6 @@
          format/1,
          read_binary/2,
          to_frames/3,
-         send/4,
          to_binary/1
         ]).
 
@@ -28,12 +27,16 @@ format(Payload) ->
 read_binary(Bin, _H=#frame_header{length=0}) ->
     {ok, #data{data= <<>>}, Bin};
 read_binary(Bin, H=#frame_header{length=L}) ->
-    lager:info("read_binary L: ~p, actually: ~p", [L, byte_size(Bin)]),
+    lager:debug("read_binary L: ~p, actually: ~p", [L, byte_size(Bin)]),
     <<PayloadBin:L/binary,Rem/bits>> = Bin,
     Data = http2_padding:read_possibly_padded_payload(PayloadBin, H),
     {ok, #data{data=Data}, Rem}.
 
--spec to_frames(stream_id(), binary(), settings()) -> [frame()].
+-spec to_frames(stream_id(), iodata(), settings()) -> [frame()].
+to_frames(StreamId, IOList, Settings)
+  when is_list(IOList) ->
+    to_frames(StreamId, iolist_to_binary(IOList), Settings);
+
 to_frames(StreamId, Data, S=#settings{max_frame_size=MFS}) ->
     L = byte_size(Data),
     case L >= MFS of
@@ -44,7 +47,6 @@ to_frames(StreamId, Data, S=#settings{max_frame_size=MFS}) ->
                  flags=?FLAG_END_STREAM,
                  stream_id=StreamId
                 }, #data{data=Data}}];
-            %%[[<<L:24,?DATA:8,?FLAG_END_STREAM:8,0:1,StreamId:31>>,Data]];
         true ->
             <<ToSend:MFS/binary,Rest/binary>> = Data,
             [{#frame_header{
@@ -53,26 +55,9 @@ to_frames(StreamId, Data, S=#settings{max_frame_size=MFS}) ->
                  stream_id=StreamId
                 },
               #data{data=ToSend}} | to_frames(StreamId, Rest, S)]
-            %%[[<<MFS:24,?DATA:8,0:8,0:1,StreamId:31>>,ToSend] | to_frames(StreamId, Rest, S)]
     end.
 
-%% TODO for POC response, Hardcoded
-send({Transport, Socket}, StreamId, Data, Settings) ->
-    Frames = to_frames(StreamId, Data, Settings),
-    %%lager:info("send Frames: ~p", [Frames]),
-    %%[ begin lager:info("F: ~p", [F]),  Transport:send(Socket, F) end || F <- Frames].
-    [ Transport:send(Socket, F) || F <- Frames].
 
 -spec to_binary(data()) -> iodata().
 to_binary(#data{data=D}) ->
     D.
-
-%    L = byte_size(Data),
-%    case L >= 16384 of
-%        false ->
-%            Transport:send(Socket, [<<L:24,?DATA:8,?FLAG_END_STREAM:8,0:1,StreamId:31>>,Data]);
-%        true ->
-%            <<ToSend:16384/binary,Rest/binary>> = Data,
-%            Transport:send(Socket, [<<16384:24,?DATA:8,0:8,0:1,StreamId:31>>,ToSend]),
-%            send({Transport,Socket}, StreamId, Rest)
-%    end.

--- a/src/http2_frame_data.erl
+++ b/src/http2_frame_data.erl
@@ -36,7 +36,6 @@ read_binary(Bin, H=#frame_header{length=L}) ->
 to_frames(StreamId, IOList, Settings)
   when is_list(IOList) ->
     to_frames(StreamId, iolist_to_binary(IOList), Settings);
-
 to_frames(StreamId, Data, S=#settings{max_frame_size=MFS}) ->
     L = byte_size(Data),
     case L >= MFS of

--- a/src/http2_frame_headers.erl
+++ b/src/http2_frame_headers.erl
@@ -40,11 +40,11 @@ is_priority(#frame_header{flags=F}) when ?IS_FLAG(F, ?FLAG_PRIORITY) ->
 is_priority(_) ->
     false.
 
--spec to_frame(pos_integer(), hpack:headers(), hpack:encode_context()) ->
-                      {{frame_header(), headers()}, hpack:encode_context()}.
+-spec to_frame(pos_integer(), hpack:headers(), hpack:context()) ->
+                      {{frame_header(), headers()}, hpack:context()}.
 %% Maybe break this up into continuations like the data frame
 to_frame(StreamId, Headers, EncodeContext) ->
-    {HeadersToSend, NewContext} = hpack:encode(Headers, EncodeContext),
+    {ok, {HeadersToSend, NewContext}} = hpack:encode(Headers, EncodeContext),
     L = byte_size(HeadersToSend),
     {{#frame_header{
          length=L,

--- a/src/http2_frame_push_promise.erl
+++ b/src/http2_frame_push_promise.erl
@@ -27,11 +27,11 @@ read_binary(Bin, H=#frame_header{length=L}) ->
                 },
     {ok, Payload, Rem}.
 
--spec to_frame(pos_integer(), pos_integer(), hpack:headers(), hpack:encode_context()) ->
-                      {{frame_header(), push_promise()}, hpack:encode_context()}.
+-spec to_frame(pos_integer(), pos_integer(), hpack:headers(), hpack:context()) ->
+                      {{frame_header(), push_promise()}, hpack:context()}.
 %% Maybe break this up into continuations like the data frame
 to_frame(StreamId, PStreamId, Headers, EncodeContext) ->
-    {HeadersToSend, NewContext} = hpack:encode(Headers, EncodeContext),
+    {ok, {HeadersToSend, NewContext}} = hpack:encode(Headers, EncodeContext),
     L = byte_size(HeadersToSend),
     {{#frame_header{
          length=L,

--- a/test/flow_control_SUITE.erl
+++ b/test/flow_control_SUITE.erl
@@ -93,7 +93,7 @@ send_n_bytes(N) ->
          {<<":path">>, <<"/">>},
          {<<":method">>, <<"POST">>}
         ],
-    {HeadersBin, _EncodeContext} = hpack:encode(Headers, hpack:new_encode_context()),
+    {ok, {HeadersBin, _EncodeContext}} = hpack:encode(Headers, hpack:new_context()),
 
     HeaderFrame = {#frame_header{
                       length=byte_size(HeadersBin),

--- a/test/header_continuation_SUITE.erl
+++ b/test/header_continuation_SUITE.erl
@@ -34,7 +34,7 @@ basic_continuation(_Config) ->
                {<<"user-agent">>, <<"nghttp2/0.7.7">>}
               ],
 
-    {HeadersBin, _NewContext} = hpack:encode(Headers, hpack:new_encode_context()),
+    {ok, {HeadersBin, _NewContext}} = hpack:encode(Headers, hpack:new_context()),
 
     <<H1:8/binary,H2:8/binary,H3/binary>> = HeadersBin,
 
@@ -66,7 +66,7 @@ basic_continuation_end_stream_first(_Config) ->
                {<<"user-agent">>, <<"nghttp2/0.7.7">>}
               ],
 
-    {HeadersBin, _NewContext} = hpack:encode(Headers, hpack:new_encode_context()),
+    {ok, {HeadersBin, _NewContext}} = hpack:encode(Headers, hpack:new_context()),
 
     <<H1:8/binary,H2:8/binary,H3/binary>> = HeadersBin,
 
@@ -97,7 +97,7 @@ bad_frame_wrong_type_between_continuations(_Config) ->
                {<<"user-agent">>, <<"nghttp2/0.7.7">>}
               ],
 
-    {HeadersBin, _NewContext} = hpack:encode(Headers, hpack:new_encode_context()),
+    {ok, {HeadersBin, _NewContext}} = hpack:encode(Headers, hpack:new_context()),
 
     <<H1:8/binary,H2:8/binary,H3/binary>> = HeadersBin,
 
@@ -133,7 +133,7 @@ bad_frame_wrong_stream_between_continuations(_Config) ->
                {<<"user-agent">>, <<"nghttp2/0.7.7">>}
               ],
 
-    {HeadersBin, _NewContext} = hpack:encode(Headers, hpack:new_encode_context()),
+    {ok, {HeadersBin, _NewContext}} = hpack:encode(Headers, hpack:new_context()),
 
     <<H1:8/binary,H2:8/binary,H3/binary>> = HeadersBin,
 

--- a/test/http2_frame_size_SUITE.erl
+++ b/test/http2_frame_size_SUITE.erl
@@ -69,22 +69,22 @@ euc(_Config) ->
                {<<"user-agent">>, <<"my cool browser">>},
                {<<"x-custom-header">>, <<"some custom value">>}
               ],
-    HeaderContext1 = hpack:new_encode_context(),
-    {HeadersBin1, HeaderContext2} = hpack:encode(Headers1, HeaderContext1),
+    HeaderContext1 = hpack:new_context(),
+    {ok, {HeadersBin1, HeaderContext2}} = hpack:encode(Headers1, HeaderContext1),
 
     Headers2 = [
                {<<":path">>, <<"/some_file.html">>},
                {<<"user-agent">>, <<"my cool browser">>},
                {<<"x-custom-header">>, <<"some custom value">>}
               ],
-    {HeadersBin2, HeaderContext3} = hpack:encode(Headers2, HeaderContext2),
+    {ok, {HeadersBin2, HeaderContext3}} = hpack:encode(Headers2, HeaderContext2),
 
     Headers3 = [
                {<<":path">>, <<"/some_file.html">>},
                {<<"user-agent">>, <<"my cool browser">>},
                {<<"x-custom-header">>, <<"new value">>}
               ],
-    {HeadersBin3, _HeaderContext4} = hpack:encode(Headers3, HeaderContext3),
+    {ok, {HeadersBin3, _HeaderContext4}} = hpack:encode(Headers3, HeaderContext3),
 
     Frames = [
               {#frame_header{length=byte_size(HeadersBin1),type=?HEADERS,flags=?FLAG_END_HEADERS,stream_id=3},#headers{block_fragment=HeadersBin1}},

--- a/test/http2c.erl
+++ b/test/http2c.erl
@@ -39,7 +39,7 @@
 -record(http2c_state, {
           socket :: undefined | {gen_tcp, gen_tcp:socket()} | {ssl, ssl:sslsocket()},
           send_settings = #settings{} :: settings(),
-          encode_context = hpack:new_encode_context() :: hpack:encode_context(),
+          encode_context = hpack:new_context() :: hpack:context(),
           next_available_stream_id = 1 :: pos_integer(),
           incoming_frames = [] :: [frame()],
           working_frame_header = undefined :: undefined | frame_header(),


### PR DESCRIPTION
`iodata()`... I OWE DATA! Get it? GET IT?!

please clap.

Also fixes

```
  4.3. Header Compression and Decompression
    ✓ Sends invalid header block fragment
    ✓ Sends Dynamic Table Size Update (RFC 7541, 6.3)
    × Encodes Dynamic Table Size Update (RFC 7541, 6.3) after common header fields
      - The endpoint MUST terminate the connection with a connection error of type COMPRESSION_ERROR.
        Expected: GOAWAY frame (ErrorCode: COMPRESSION_ERROR)
                  Connection close
          Actual: DATA frame (Length: 16, Flags: 1)
``` 

found with h2spec. thanks for showing me that @tsloughter 

see joedevivo/hpack#5 for more info