### PR TITLE
4.3. Header Compression and Decompression: Encodes Dynamic Table Size Update (RFC 7541, 6.3) after common header fields

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
   1},
  {<<"hpack">>,
   {git,"git://github.com/joedevivo/hpack.git",
-       {ref,"a20c3cca97b4d00f208aa34621835cec1cf74948"}},
+       {ref,"7e105f6ce9953a234a70cba779b3ef4e938e21e0"}},
   0},
  {<<"lager">>,
   {git,"git://github.com/basho/lager.git",

--- a/test/http2_frame_size_SUITE.erl
+++ b/test/http2_frame_size_SUITE.erl
@@ -47,7 +47,13 @@ send_wrong_size(Type, _Config) ->
 frame_too_big(_Config) ->
     {ok, Client} = http2c:start_link(),
     Frames = [
-        {#frame_header{length=16392,type=?HEADERS,flags=?FLAG_END_HEADERS,stream_id=3}, #headers{block_fragment = <<1:131136>>}}
+        {
+          #frame_header{
+             length=16392,
+             type=?HEADERS,
+             flags=?FLAG_END_HEADERS,
+             stream_id=3},
+          #headers{block_fragment = <<1:131136>>}}
     ],
     http2c:send_unaltered_frames(Client, Frames),
 

--- a/test/http2_spec_4_3_SUITE.erl
+++ b/test/http2_spec_4_3_SUITE.erl
@@ -1,0 +1,35 @@
+-module(http2_spec_4_3_SUITE).
+
+-include("http2.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-compile([export_all]).
+
+all() ->
+    [
+     sends_invalid_header_block_fragment
+    ].
+
+init_per_suite(Config) ->
+    application:ensure_started(crypto),
+    chatterbox_test_buddy:start(Config).
+
+end_per_suite(Config) ->
+    chatterbox_test_buddy:stop(Config),
+    ok.
+
+sends_invalid_header_block_fragment(_Config) ->
+    {ok, Client} = http2c:start_link(),
+
+    %% Bad Header Block, Literal Header Field with Incremental
+    %% Indexing without Length and String segment
+    Bin = <<16#00,16#00,16#01,16#01,16#05,
+            16#00,16#00,16#00,16#01,16#40>>,
+    http2c:send_binary(Client, Bin),
+
+    Resp = http2c:wait_for_n_frames(Client, 0, 1),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(1, length(Resp)),
+    [{_GoAwayH, GoAway}] = Resp,
+    ?COMPRESSION_ERROR = GoAway#goaway.error_code,
+    ok.


### PR DESCRIPTION
```
  4.3. Header Compression and Decompression
    × Encodes Dynamic Table Size Update (RFC 7541, 6.3) after common header fields
      - The endpoint MUST terminate the connection with a connection error of type COMPRESSION_ERROR.
        Expected: GOAWAY frame (ErrorCode: COMPRESSION_ERROR)
                  Connection close
          Actual: DATA frame (Length: 16, Flags: 1)
```