### PR TITLE
6.5.2. Defined SETTINGS Parameters: SETTINGS_INITIAL_WINDOW_SIZE (0x4): Sends the value above the maximum flow control window size

### DIFF
--- a/src/http2_frame_settings.erl
+++ b/src/http2_frame_settings.erl
@@ -172,6 +172,9 @@ validate_([]) ->
 validate_([{?SETTINGS_ENABLE_PUSH, Push}|_T])
   when Push > 1; Push < 0 ->
     {error, ?PROTOCOL_ERROR};
+validate_([{?SETTINGS_INITIAL_WINDOW_SIZE, Size}|_T])
+  when Size >=2147483648 ->
+    {error, ?FLOW_CONTROL_ERROR};
 validate_([_H|T]) ->
     validate_(T).
 
@@ -197,6 +200,9 @@ validate_test() ->
     ?assertEqual(ok, validate_([{?SETTINGS_ENABLE_PUSH, 1}])),
     ?assertEqual({error, ?PROTOCOL_ERROR}, validate_([{?SETTINGS_ENABLE_PUSH, 2}])),
     ?assertEqual({error, ?PROTOCOL_ERROR}, validate_([{?SETTINGS_ENABLE_PUSH, -1}])),
+    ?assertEqual({error, ?FLOW_CONTROL_ERROR}, validate_([{?SETTINGS_INITIAL_WINDOW_SIZE, 2147483648}])),
+    ?assertEqual(ok, validate_([{?SETTINGS_INITIAL_WINDOW_SIZE, 2147483647}])),
+
     ok.
 
 -endif.

--- a/test/http2_spec_6_5_SUITE.erl
+++ b/test/http2_spec_6_5_SUITE.erl
@@ -7,7 +7,8 @@
 
 all() ->
     [
-     sends_invalid_push_setting
+     sends_invalid_push_setting,
+     sends_value_above_max_flow_control_window_size
     ].
 
 init_per_suite(Config) ->
@@ -31,4 +32,17 @@ sends_invalid_push_setting(_Config) ->
     ?assertEqual(1, length(Resp)),
     [{_GoAwayH, GoAway}] = Resp,
     ?PROTOCOL_ERROR = GoAway#goaway.error_code,
+    ok.
+
+sends_value_above_max_flow_control_window_size(_Config) ->
+    {ok, Client} = http2c:start_link(),
+    Bin = <<16#00,16#00,16#06,16#04,16#00,16#00,16#00,16#00,16#00,
+            16#00,16#04,16#80,16#00,16#00,16#00>>,
+    http2c:send_binary(Client, Bin),
+
+    Resp = http2c:wait_for_n_frames(Client, 0, 1),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(1, length(Resp)),
+    [{_GoAwayH, GoAway}] = Resp,
+    ?FLOW_CONTROL_ERROR = GoAway#goaway.error_code,
     ok.

--- a/test/http2_spec_6_5_SUITE.erl
+++ b/test/http2_spec_6_5_SUITE.erl
@@ -1,0 +1,34 @@
+-module(http2_spec_6_5_SUITE).
+
+-include("http2.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-compile([export_all]).
+
+all() ->
+    [
+     sends_invalid_push_setting
+    ].
+
+init_per_suite(Config) ->
+    application:ensure_started(crypto),
+    chatterbox_test_buddy:start(Config).
+
+end_per_suite(Config) ->
+    chatterbox_test_buddy:stop(Config),
+    ok.
+
+sends_invalid_push_setting(_Config) ->
+    {ok, Client} = http2c:start_link(),
+
+    %% Settings frame with SETTINGS_ENABLE_PUSH = 2
+    Bin = <<16#00,16#00,16#06,16#04,16#00,16#00,16#00,16#00,16#00,
+            16#00,16#02,16#00,16#00,16#00,16#02>>,
+    http2c:send_binary(Client, Bin),
+
+    Resp = http2c:wait_for_n_frames(Client, 0, 1),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(1, length(Resp)),
+    [{_GoAwayH, GoAway}] = Resp,
+    ?PROTOCOL_ERROR = GoAway#goaway.error_code,
+    ok.


### PR DESCRIPTION
```
    6.5.2. Defined SETTINGS Parameters
      × SETTINGS_INITIAL_WINDOW_SIZE (0x4): Sends the value above the maximum flow control window size
        - The endpoint MUST respond with a connection error of type FLOW_CONTROL_ERROR.
          Expected: GOAWAY frame (ErrorCode: FLOW_CONTROL_ERROR)
                    Connection close
            Actual: SETTINGS frame (Length: 0, Flags: 1)
```