### PR TITLE
5.5. Extending HTTP/2: Sends an unknown extension frame

### DIFF
--- a/include/http2.hrl
+++ b/include/http2.hrl
@@ -19,7 +19,8 @@
                     | ?PING
                     | ?GOAWAY
                     | ?WINDOW_UPDATE
-                    | ?CONTINUATION.
+                    | ?CONTINUATION
+                    | integer(). %% boo!
 
 -define(FT, fun(?DATA) -> "DATA";
                (?HEADERS) -> "HEADERS";
@@ -30,7 +31,8 @@
                (?PING) -> "PING";
                (?GOAWAY) -> "GOAWAY";
                (?WINDOW_UPDATE) -> "WINDOW_UPDATE";
-               (?CONTINUATION) -> "CONTINUATION" end
+               (?CONTINUATION) -> "CONTINUATION";
+               (_) -> "UNSUPPORTED EXPANSION type" end
   ).
 
 %% ERROR CODES
@@ -181,7 +183,8 @@
                  | ping()
                  | goaway()
                  | window_update()
-                 | continuation().
+                 | continuation()
+                 | binary().
 
 -type frame() :: {frame_header(), payload()}.
 

--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -835,7 +835,10 @@ route_frame(F={H=#frame_header{stream_id=StreamId}, #window_update{}},
               }}
 
     end;
-
+route_frame({#frame_header{type=T}, _}, Conn)
+  when T > ?CONTINUATION ->
+    lager:debug("Ignoring Unsupported Expansion Frame"),
+    {next_state, connected, Conn};
 route_frame(Frame, #connection{}=Conn) ->
     lager:error("[~p] Frame condition not covered by pattern match",
                [Conn#connection.type]),

--- a/test/http2_spec_5_5_SUITE.erl
+++ b/test/http2_spec_5_5_SUITE.erl
@@ -1,0 +1,49 @@
+-module(http2_spec_5_5_SUITE).
+
+-include("http2.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-compile([export_all]).
+
+all() ->
+    [
+     sends_unknown_extension_frame
+    ].
+
+init_per_suite(Config) ->
+    application:ensure_started(crypto),
+    chatterbox_test_buddy:start(Config).
+
+end_per_suite(Config) ->
+    chatterbox_test_buddy:stop(Config),
+    ok.
+
+sends_unknown_extension_frame(_Config) ->
+    {ok, Client} = http2c:start_link(),
+
+
+    %% Some FF type frame that doesn't exist
+    Bin = <<16#00,16#00,16#01,16#ff,16#00,16#00,16#00,16#00,16#00,
+            16#00>>,
+    http2c:send_binary(Client, Bin),
+
+    %% It should be ignored, so let's send a ping and get one back
+    http2c:send_unaltered_frames(Client,
+                                 [
+                                  {#frame_header{
+                                      type=?PING,
+                                      stream_id=0,
+                                      length=8
+                                     },
+                                   #ping{
+                                      opaque_data= crypto:rand_bytes(8)
+                                     }}
+                                 ]),
+
+
+    Resp = http2c:wait_for_n_frames(Client, 0, 1),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(1, length(Resp)),
+    [{PingH, _PingBody}] = Resp,
+    ?PING = PingH#frame_header.type,
+    ok.


### PR DESCRIPTION
```
  5.5. Extending HTTP/2
    × Sends an unknown extension frame
      - The endpoint MUST discard frames that have unknown or unsupported types
        Expected: PING frame (Flags: 1)
          Actual: Connection close
```