### PR TITLE
6.9.1. The Flow Control Window: Sends multiple WINDOW_UPDATE frames on a connection increasing the flow control window to above 2^31-1

### DIFF
--- a/src/chatterbox.app.src
+++ b/src/chatterbox.app.src
@@ -17,7 +17,6 @@
    [
     {port, 80},
     {concurrent_acceptors, 20},
-    {content_handler, chatterbox_static_content_handler},
 
     %% These are the defaults for ALL HTTP/2 clients. You can change
     %% any of them that you want to, but these will be the ones used

--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -514,9 +514,10 @@ route_frame(F={H=#frame_header{
             %% Make window size great again
             lager:info("[~p] Stream ~p WindowUpdate ~p",
                        [Conn#connection.type, StreamId, L]),
-            send_window_update(self(), L),
-            gen_fsm:send_all_state_event(StreamPid, {send_window_update, L});
-        _ ->
+
+            gen_fsm:send_all_state_event(StreamPid, {send_window_update, L}),
+            send_window_update(self(), L);
+        _Tried ->
             ok
     end,
 
@@ -690,11 +691,11 @@ route_frame({H, _Payload},
                [Conn#connection.type]),
     {next_state, connected, Conn};
 %% TODO: RST_STREAM support
-route_frame({H=#frame_header{stream_id=StreamId}, _Payload},
+route_frame({H=#frame_header{stream_id=StreamId}, #rst_stream{error_code=EC}},
             #connection{}=Conn)
     when H#frame_header.type == ?RST_STREAM ->
-    lager:error("[~p] Received RST_STREAM for Stream ~p, but did nothing with it",
-                [Conn#connection.type, StreamId]),
+    lager:error("[~p] Received RST_STREAM (~p) for Stream ~p, but did nothing with it",
+                [Conn#connection.type, EC, StreamId]),
     {next_state, connected, Conn};
 route_frame({H=#frame_header{
                   stream_id=StreamId,
@@ -797,22 +798,18 @@ route_frame({H=#frame_header{stream_id=0}, _Payload},
     lager:debug("[~p] Received GOAWAY Frame for Stream 0",
                [Conn#connection.type]),
     go_away(?NO_ERROR, Conn);
-route_frame({H=#frame_header{stream_id=StreamId}, _Payload},
-            #connection{}=Conn)
-    when H#frame_header.type == ?GOAWAY ->
-    lager:debug("[~p] Received GOAWAY Frame for Stream ~p",
-                [Conn#connection.type, StreamId]),
-    lager:error("[~p] Chatterbox doesn't support streams. Throwing this GOAWAY away",
-               [Conn#connection.type]),
-    {next_state, connected, Conn};
-route_frame({H=#frame_header{stream_id=0},
-             #window_update{window_size_increment=WSI}},
-            #connection{
-               send_window_size=SWS,
-               queued_frames=QF,
-               streams=Streams
-              }=Conn)
-    when H#frame_header.type == ?WINDOW_UPDATE ->
+route_frame(
+  {#frame_header{
+      stream_id=0,
+      type=?WINDOW_UPDATE
+     },
+   #window_update{window_size_increment=WSI}},
+  #connection{
+     send_window_size=SWS,
+     queued_frames=QF,
+     streams=Streams
+    }=Conn) ->
+
     lager:debug("[~p] Stream 0 Window Update: ~p",
                 [Conn#connection.type, WSI]),
     NewSendWindow = SWS+WSI,
@@ -878,13 +875,16 @@ route_frame(Frame, #connection{}=Conn) ->
     lager:error("OOPS! ~p", [Conn]),
     go_away(?PROTOCOL_ERROR, Conn).
 
+handle_event({send_window_update, 0},
+             StateName, Conn) ->
+    {next_state, StateName, Conn};
 handle_event({send_window_update, Size},
              StateName,
              #connection{
                 recv_window_size=CRWS,
                 socket=Socket
                 }=Conn) ->
-    http2_frame_window_update:send(Socket, Size, 0),
+    ok = http2_frame_window_update:send(Socket, Size, 0),
     {next_state,
      StateName,
      Conn#connection{

--- a/src/http2_frame_queue.erl
+++ b/src/http2_frame_queue.erl
@@ -4,7 +4,8 @@
 
 -export([
          connection_ketchup/3,
-         stream_ketchup/4
+         stream_ketchup/4,
+         remove/2
         ]).
 
 
@@ -151,4 +152,19 @@ ketchup(#accumulator{
                        },
                       Tail)
             end
+    end.
+
+remove(StreamId, QF) ->
+    remove(StreamId, queue:new(), QF).
+
+remove(StreamId, Acc, QF) ->
+    case queue:out(QF) of
+        {empty, _} ->
+            Acc;
+        {{value, {#frame_header{
+                     stream_id=StreamId
+                    },_}}, Remaining} ->
+            remove(StreamId, Acc, Remaining);
+        {{value, F}, Remaining} ->
+            remove(StreamId, queue:in(F, Acc), Remaining)
     end.

--- a/src/http2_stream.erl
+++ b/src/http2_stream.erl
@@ -90,7 +90,6 @@
           state = idle :: stream_state_name(),
           send_window_size = ?DEFAULT_INITIAL_WINDOW_SIZE :: integer(),
           recv_window_size = ?DEFAULT_INITIAL_WINDOW_SIZE :: integer(),
-          queued_frames = queue:new() :: queue:queue(frame()),
           incoming_frames = queue:new() :: queue:queue(frame()),
           request_headers = [] :: hpack:headers(),
           request_body :: iodata(),
@@ -166,7 +165,7 @@ recv_es(Pid) ->
     gen_fsm:send_event(Pid, recv_es).
 
 -spec recv_wu(pid(), {frame_header(), window_update()}) ->
-                     ok.
+                     ok | {error, flow_control}.
 recv_wu(Pid, Frame) ->
     gen_fsm:sync_send_all_state_event(Pid, {recv_wu, Frame}).
 
@@ -421,11 +420,24 @@ open(Msg, Stream) ->
 open({send_frame,
       {#frame_header{
           type=?DATA,
-          flags=Flags
+          length=L
+         }, _}=_F},
+     _From,
+     #stream_state{
+        send_window_size=SWS
+       }=Stream)
+  when L > SWS ->
+    {reply, flow_control, open, Stream};
+open({send_frame,
+      {#frame_header{
+          type=?DATA,
+          flags=Flags,
+          length=L
          }, _}=F},
      _From,
      #stream_state{
-        socket=Socket
+        socket=Socket,
+        send_window_size=SWS
        }=Stream) ->
     sock:send(Socket, http2_frame:to_binary(F)),
 
@@ -436,7 +448,8 @@ open({send_frame,
             _ ->
                 open
         end,
-    {reply, ok, NextState, Stream}.
+    {reply, ok, NextState,
+     Stream#stream_state{send_window_size=SWS-L}}.
 
 half_closed_remote(
   {send_h, Headers},
@@ -451,26 +464,44 @@ half_closed_remote(
                   {send_frame,
                    {
                      #frame_header{
-                        flags=Flags
+                        type=?DATA,
+                        length=L
+                       },_
+                   }}=_Msg,
+  _From,
+  #stream_state{
+     send_window_size=SWS
+    }=Stream)
+  when L > SWS ->
+    {reply, flow_control, half_closed_remote, Stream};
+half_closed_remote(
+                  {send_frame,
+                   {
+                     #frame_header{
+                        flags=Flags,
+                        type=?DATA,
+                        length=L
                        },_
                    }=F}=_Msg,
   _From,
   #stream_state{
-     socket=Socket
+     socket=Socket,
+     send_window_size=SWS
     }=Stream) ->
     ok = sock:send(Socket, http2_frame:to_binary(F)),
 
     NextState =
         case ?IS_FLAG(Flags, ?FLAG_END_STREAM) of
             true ->
-                lager:error("half_closed remote -> closed ~p",
-                            [Stream#stream_state.stream_id]),
+                %lager:error("half_closed remote -> closed ~p",
+                %            [Stream#stream_state.stream_id]),
                 closed;
         _ ->
                 half_closed_remote
         end,
 
-    {reply, ok, NextState, Stream}.
+    {reply, ok, NextState,
+     Stream#stream_state{send_window_size=SWS-L}}.
 
 %% PUSH_PROMISES can only be received by streams in the open or
 %% half_closed_local, but will create a new stream in the idle state,
@@ -548,6 +579,10 @@ handle_event({modify_recv_window_size, Delta},
      Stream#stream_state{
        recv_window_size=RWS - Delta
       }};
+handle_event({send_window_update, 0},
+             StateName,
+             #stream_state{}=Stream) ->
+    {next_state, StateName, Stream};
 handle_event({send_window_update, Size},
              StateName,
              #stream_state{
@@ -583,27 +618,21 @@ handle_sync_event({recv_wu,
                   StateName,
               #stream_state{
                  stream_id=StreamId,
-                 send_window_size=SWS,
-                 queued_frames=QF
+                 send_window_size=SWS
                 }=Stream)
              ->
     NewSendWindow = WSI + SWS,
     case NewSendWindow > 2147483647 of
         true ->
+            lager:error("Sending ~p FLOWCONTROL ERROR because NSW = ~p", [StreamId, NewSendWindow]),
             rst_stream_(?FLOW_CONTROL_ERROR, Stream),
-            {next_state, {error, flow_control}, closed, Stream};
+            {reply, {error, flow_control}, closed, Stream};
         false ->
             NewStream = Stream#stream_state{
-                          send_window_size=NewSendWindow,
-                          queued_frames=queue:new()
+                          send_window_size=NewSendWindow
                          },
             lager:debug("Stream ~p send window now: ~p", [StreamId, NewSendWindow]),
-            %% TODO: This fold is the previous version of window update
-            lists:foldl(
-              fun(Frame, S) -> send_frame(Frame, S) end,
-              NewStream,
-              queue:to_list(QF)),
-            {next_state, ok, StateName, Stream}
+            {reply, ok, StateName, NewStream}
     end;
 
 


### PR DESCRIPTION
```
    6.9.1. The Flow Control Window
      × Sends multiple WINDOW_UPDATE frames on a connection increasing the flow control window to above 2^31-1
        - The endpoint MUST sends a GOAWAY frame with a FLOW_CONTROL_ERROR code.
          Expected: GOAWAY frame (ErrorCode: FLOW_CONTROL_ERROR)
            Actual: Test timeout
```