### PR TITLE
5.1. Stream States: idle: Sends a WINDOW_UPDATE frame

### DIFF
--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -855,9 +855,9 @@ route_frame(F={H=#frame_header{stream_id=StreamId}, #window_update{}},
 
     case StreamPid of
         undefined ->
-            lager:error("[~p] Window update for a stream that we don't think exists!",
-                       [Conn#connection.type]),
-            {next_state, connected, Conn};
+            lager:error("[~p] Window update for an idle stream (~p)",
+                       [Conn#connection.type, StreamId]),
+            go_away(?PROTOCOL_ERROR, Conn);
         _ ->
             case http2_stream:recv_wu(StreamPid, F) of
                 ok ->


### PR DESCRIPTION
```
  5.1. Stream States
    × idle: Sends a WINDOW_UPDATE frame
      - The endpoint MUST treat this as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
        Expected: GOAWAY frame (ErrorCode: PROTOCOL_ERROR)
                  Connection close
          Actual: Test timeout
```