### PR TITLE
5.3.1. Stream Dependencies: Sends HEADERS frame that depend on itself

### DIFF
--- a/include/http2.hrl
+++ b/include/http2.hrl
@@ -105,9 +105,9 @@
 -type headers() :: #headers{}.
 
 -record(priority, {
-    exclusive :: 0 | 1,
-    stream_id :: stream_id(),
-    weight :: pos_integer()
+    exclusive = 0 :: 0 | 1,
+    stream_id = 0 :: stream_id(),
+    weight = 0 :: non_neg_integer()
   }).
 -type priority() :: #priority{}.
 

--- a/test/http2_spec_5_3_SUITE.erl
+++ b/test/http2_spec_5_3_SUITE.erl
@@ -1,0 +1,62 @@
+-module(http2_spec_5_3_SUITE).
+
+-include("http2.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-compile([export_all]).
+
+all() ->
+    [
+     sends_header_frame_that_depends_on_itself
+    ].
+
+init_per_suite(Config) ->
+    application:ensure_started(crypto),
+    chatterbox_test_buddy:start(Config).
+
+end_per_suite(Config) ->
+    chatterbox_test_buddy:stop(Config),
+    ok.
+
+sends_header_frame_that_depends_on_itself(_Config) ->
+    {ok, Client} = http2c:start_link(),
+
+    RequestHeaders =
+        [
+         {<<":method">>, <<"GET">>},
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ],
+
+    {ok, {HeadersBin, _}} = hpack:encode(RequestHeaders, hpack:new_context()),
+    L = byte_size(HeadersBin) + 5,
+    F = {
+      #frame_header{
+         stream_id=1,
+         length=L,
+         flags=?FLAG_END_HEADERS bor ?FLAG_PRIORITY,
+         type=?HEADERS
+        },
+      #headers{
+         priority=#priority{
+                     exclusive=0,
+                     stream_id=1,
+                     weight=1
+                    },
+         block_fragment=HeadersBin
+        }
+     },
+
+
+    http2c:send_unaltered_frames(Client, [F]),
+
+    Resp = http2c:wait_for_n_frames(Client, 1, 1),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(1, length(Resp)),
+    [{_Header, Payload}] = Resp,
+    ?PROTOCOL_ERROR = Payload#rst_stream.error_code,
+    ok.


### PR DESCRIPTION
```
    5.3.1. Stream Dependencies
      × Sends HEADERS frame that depend on itself
        - The endpoint MUST treat this as a stream error of type PROTOCOL_ERROR
          Expected: GOAWAY frame (ErrorCode: PROTOCOL_ERROR)
                    RST_STREAM frame (ErrorCode: PROTOCOL_ERROR)
                    Connection close
            Actual: DATA frame (Length: 16, Flags: 1)
```