### PR TITLE
6.2. HEADERS: Sends a HEADERS frame with invalid pad length

### DIFF
--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -539,7 +539,6 @@ route_frame({#frame_header{stream_id=StreamId, type=?HEADERS}=FH, #headers{prior
   when ?IS_FLAG(FH#frame_header.flags, ?FLAG_PRIORITY),
        P#priority.stream_id == FH#frame_header.stream_id ->
     rst_stream(StreamId, ?PROTOCOL_ERROR, Conn);
-
 route_frame({#frame_header{type=?HEADERS}=FH, _Payload}=Frame,
             #connection{}=Conn) ->
     StreamId = FH#frame_header.stream_id,
@@ -1388,7 +1387,9 @@ handle_socket_data(Data,
             {next_state, StateName, NewConn#connection{buffer={binary, Bin}}};
         %% Not enough bytes to make a payload
         {error, not_enough_payload, Header, Bin} ->
-            {next_state, StateName, NewConn#connection{buffer={frame, Header, Bin}}}
+            {next_state, StateName, NewConn#connection{buffer={frame, Header, Bin}}};
+        {error, Code} ->
+            go_away(Code, Conn)
     end.
 
 handle_socket_passive(StateName, Conn) ->

--- a/src/http2_frame_headers.erl
+++ b/src/http2_frame_headers.erl
@@ -18,22 +18,28 @@ format(Payload) ->
     io_lib:format("[Headers: ~p]", [Payload]).
 
 -spec read_binary(binary(), frame_header()) ->
-    {ok, payload(), binary()} | {error, term()}.
+                         {ok, payload(), binary()}
+                       | {error, error_code()}.
 read_binary(Bin, H = #frame_header{length=L}) ->
     <<PayloadBin:L/binary,Rem/bits>> = Bin,
-    Data = http2_padding:read_possibly_padded_payload(PayloadBin, H),
-    {Priority, HeaderFragment} = case is_priority(H) of
-        true ->
-            http2_frame_priority:read_priority(Data);
-        false ->
-            {undefined, Data}
-    end,
+    case http2_padding:read_possibly_padded_payload(PayloadBin, H) of
+        {error, Code} ->
+            {error, Code};
+        Data ->
+            {Priority, HeaderFragment} =
+                case is_priority(H) of
+                    true ->
+                        http2_frame_priority:read_priority(Data);
+                    false ->
+                        {undefined, Data}
+                end,
 
-    Payload = #headers{
-                 priority=Priority,
-                 block_fragment=HeaderFragment
-                },
-    {ok, Payload, Rem}.
+            Payload = #headers{
+                         priority=Priority,
+                         block_fragment=HeaderFragment
+                        },
+            {ok, Payload, Rem}
+    end.
 
 is_priority(#frame_header{flags=F}) when ?IS_FLAG(F, ?FLAG_PRIORITY) ->
     true;
@@ -55,7 +61,6 @@ to_frame(StreamId, Headers, EncodeContext) ->
       #headers{
          block_fragment=HeadersToSend
         }},
-    %%{[<<L:24,?HEADERS:8,?FLAG_END_HEADERS:8,0:1,StreamId:31>>,HeadersToSend],
     NewContext}.
 
 send({Transport, Socket}, StreamId, Headers, EncodeContext) ->

--- a/test/http2_spec_6_2_SUITE.erl
+++ b/test/http2_spec_6_2_SUITE.erl
@@ -1,0 +1,58 @@
+-module(http2_spec_6_2_SUITE).
+
+-include("http2.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-compile([export_all]).
+
+all() ->
+    [
+     sends_header_with_invalid_pad_length
+    ].
+
+init_per_suite(Config) ->
+    application:ensure_started(crypto),
+    chatterbox_test_buddy:start(Config).
+
+end_per_suite(Config) ->
+    chatterbox_test_buddy:stop(Config),
+    ok.
+
+sends_header_with_invalid_pad_length(_Config) ->
+
+    {ok, Client} = http2c:start_link(),
+
+    RequestHeaders =
+        [
+         {<<":method">>, <<"GET">>},
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ],
+
+    {ok, {HeadersBin, _}} = hpack:encode(RequestHeaders, hpack:new_context()),
+    L = byte_size(HeadersBin)+1,
+    PaddedBin = <<L,HeadersBin/binary>>,
+
+    F = {
+      #frame_header{
+         stream_id=1,
+         flags=?FLAG_END_HEADERS bor ?FLAG_PADDED
+        },
+      #headers{
+         block_fragment=PaddedBin
+        }
+     },
+
+
+    http2c:send_unaltered_frames(Client, [F]),
+
+    Resp = http2c:wait_for_n_frames(Client, 0, 1),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(1, length(Resp)),
+    [{_Header, Payload}] = Resp,
+    ?PROTOCOL_ERROR = Payload#goaway.error_code,
+    ok.


### PR DESCRIPTION
```
  6.2. HEADERS
    × Sends a HEADERS frame with invalid pad length
      - The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.
        Expected: GOAWAY frame (ErrorCode: PROTOCOL_ERROR)
                  Connection close
          Actual: Test timeout
```