### PR TITLE
6.1. DATA Sends a DATA frame with invalid pad length

### DIFF
--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -1360,9 +1360,6 @@ handle_socket_data(Data,
             _ ->
                 <<>>
     end,
-    %% We need this set to active_once ASAP, otherwise we might miss a message
-    active_once(Socket),
-
     %% What is buffer?
     %% empty - nothing, yay
     %% {frame, frame_header(), binary()} - Frame Header processed, Payload not big enough
@@ -1386,9 +1383,14 @@ handle_socket_data(Data,
             handle_socket_data(Rem, StateName, NewConn);
         %% Not enough bytes left to make a header :(
         {error, not_enough_header, Bin} ->
+            %% This is a situation where more bytes should come soon,
+            %% so let's switch back to active, once
+            active_once(Socket),
             {next_state, StateName, NewConn#connection{buffer={binary, Bin}}};
         %% Not enough bytes to make a payload
         {error, not_enough_payload, Header, Bin} ->
+            %% This too
+            active_once(Socket),
             {next_state, StateName, NewConn#connection{buffer={frame, Header, Bin}}};
         {error, Code} ->
             go_away(Code, Conn)

--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -1360,6 +1360,8 @@ handle_socket_data(Data,
             _ ->
                 <<>>
     end,
+    %% We need this set to active_once ASAP, otherwise we might miss a message
+    active_once(Socket),
 
     %% What is buffer?
     %% empty - nothing, yay

--- a/src/http2_frame_data.erl
+++ b/src/http2_frame_data.erl
@@ -29,8 +29,12 @@ read_binary(Bin, _H=#frame_header{length=0}) ->
 read_binary(Bin, H=#frame_header{length=L}) ->
     lager:debug("read_binary L: ~p, actually: ~p", [L, byte_size(Bin)]),
     <<PayloadBin:L/binary,Rem/bits>> = Bin,
-    Data = http2_padding:read_possibly_padded_payload(PayloadBin, H),
-    {ok, #data{data=Data}, Rem}.
+    case http2_padding:read_possibly_padded_payload(PayloadBin, H) of
+        {error, Code} ->
+            {error, Code};
+        Data ->
+            {ok, #data{data=Data}, Rem}
+    end.
 
 -spec to_frames(stream_id(), iodata(), settings()) -> [frame()].
 to_frames(StreamId, IOList, Settings)

--- a/test/http2_spec_6_1_SUITE.erl
+++ b/test/http2_spec_6_1_SUITE.erl
@@ -1,0 +1,72 @@
+-module(http2_spec_6_1_SUITE).
+
+-include("http2.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-compile([export_all]).
+
+all() ->
+    [
+     sends_data_with_invalid_pad_length
+    ].
+
+init_per_suite(Config) ->
+    application:ensure_started(crypto),
+    chatterbox_test_buddy:start(Config).
+
+end_per_suite(Config) ->
+    chatterbox_test_buddy:stop(Config),
+    ok.
+
+sends_data_with_invalid_pad_length(_Config) ->
+
+    {ok, Client} = http2c:start_link(),
+
+    RequestHeaders =
+        [
+         {<<":method">>, <<"GET">>},
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ],
+
+    {ok, {HeadersBin, _}} = hpack:encode(RequestHeaders, hpack:new_context()),
+
+    HF = {
+      #frame_header{
+         stream_id=1,
+         flags=?FLAG_END_HEADERS bor ?FLAG_PADDED
+        },
+      #headers{
+         block_fragment=HeadersBin
+        }
+     },
+
+
+%    L = byte_size(Data)+1,
+%    PaddedData = <<L,Data/binary>>,
+%    DF = {
+%      #frame_header{
+%         stream_id=1,
+%         flags=?FLAG_END_STREAM bor ?FLAG_PADDED
+%        },
+%      #data{
+%         data=PaddedData
+%        }
+%     },
+
+    http2c:send_unaltered_frames(Client, [HF]),
+    http2c:send_binary(
+      Client,
+      <<16#00,16#00,16#05,16#00,16#0b,16#00,16#00,16#00,16#01,
+        16#06,16#54,16#65,16#73,16#74>>),
+
+    Resp = http2c:wait_for_n_frames(Client, 0, 1),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(1, length(Resp)),
+    [{_Header, Payload}] = Resp,
+    ?PROTOCOL_ERROR = Payload#goaway.error_code,
+    ok.


### PR DESCRIPTION
```
  6.1. DATA
    × Sends a DATA frame with invalid pad length
      - The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.
        Expected: GOAWAY frame (ErrorCode: PROTOCOL_ERROR)
                  RST_STREAM frame (ErrorCode: PROTOCOL_ERROR)
                  Connection close
          Actual: DATA frame (Length: 16, Flags: 1)
```