### PR TITLE
8.1. HTTP Request/Response Exchange: Sends a second HEADERS frame without the END_STREAM flag

### DIFF
--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -59,10 +59,12 @@
          }).
 
 -record(continuation_state, {
-          stream_id = undefined :: stream_id() | undefined,
-          frames = undefined :: queue:queue(frame()),
-          type = undefined :: undefined | headers | push_promise,
-          end_stream = false :: boolean()
+          stream_id                 :: stream_id(),
+          promised_id = undefined   :: undefined | stream_id(),
+          frames      = queue:new() :: queue:queue(frame()),
+          type                      :: headers | push_promise,
+          end_stream  = false       :: boolean(),
+          end_headers = false       :: boolean()
 }).
 
 
@@ -541,7 +543,7 @@ route_frame(F={H=#frame_header{
                        [Conn#connection.type, StreamId, L]),
             http2_frame_window_update:send(Conn#connection.socket,
                                            L, StreamId),
-            gen_fsm:send_all_state_event(Stream#stream.pid, {send_window_update, L}),
+            %%gen_fsm:send_all_state_event(Stream#stream.pid, {send_window_update, L}),
             send_window_update(self(), L);
         _Tried ->
             ok
@@ -577,7 +579,7 @@ route_frame({#frame_header{type=?HEADERS}=FH, _Payload}=Frame,
     lager:debug("[~p] Received HEADERS Frame for Stream ~p",
                 [Conn#connection.type, StreamId]),
 
-    %% Three things could be happening here.
+    %% Four things could be happening here.
 
     %% 1. We're a server, and these are Request Headers.
 
@@ -592,52 +594,41 @@ route_frame({#frame_header{type=?HEADERS}=FH, _Payload}=Frame,
     %% stream if this is the first scenario. The stream will already
     %% exist if this is a PP or Response
 
-    {StreamPid, NewStreams} =
+    NewConn =
         case get_stream(StreamId, Streams) of
             false ->
                 NewStream = new_stream_(StreamId, Conn),
-                {NewStream#stream.pid, [NewStream|Streams]};
-            Stream ->
-                {Stream#stream.pid, Streams}
+                Conn#connection{streams=[NewStream|Streams]};
+            _Stream ->
+                Conn
         end,
 
-    % Is ths all to the stream?
-    Flags = FH#frame_header.flags,
-    EndStream = ?IS_FLAG(Flags, ?FLAG_END_STREAM),
+    %% If there's an END_HEADERS flag, the headers were only one
+    %% frame.
 
-    %% We spawned an idle stream if it didn't exist.
-    case ?IS_FLAG(Flags, ?FLAG_END_HEADERS) of
-        true ->
-            HeadersBin = http2_frame_headers:from_frames([Frame]),
-            case hpack:decode(HeadersBin, Conn#connection.decode_context) of
-                {ok, {Headers, NewDecodeContext}} ->
-                    http2_stream:recv_h(StreamPid, Headers),
-                    case EndStream of
-                        true ->
-                            http2_stream:recv_es(StreamPid);
-                        false ->
-                            ok
-                    end,
-                    {next_state, connected,
-                     Conn#connection{
-                       streams = NewStreams,
-                       decode_context=NewDecodeContext
-                      }};
-                {error, compression_error} ->
-                    go_away(?COMPRESSION_ERROR, Conn)
-            end;
-        false ->
-            {next_state, continuation,
-             Conn#connection{
-               streams = NewStreams,
-               continuation = #continuation_state{
-                                 stream_id = StreamId,
-                                 frames = queue:from_list([Frame]),
-                                 end_stream = EndStream,
-                                 type=headers
-                                }
-              }}
-    end;
+    %% If not, we have to wait for all the CONTINUATIONS to roll in.
+
+    %% If there's an END_STREAM flag set AND END_HEADERS, we're done
+    %% with the request.
+
+    %% If there's and END_STREAM and no END_HEADERS, we'll be done
+    %% once those CONTINUATIONS arrive
+
+    %% So what do we do? We construct a #continuation record that
+    %% covers a whole bunch of things and is run through a function
+    %% when every HEADERS, PUSH_PROMISE, or CONTINUATION rolls
+    %% in. Let's give it a whirl.
+
+    ContinuationState =
+        #continuation_state{
+           type = headers,
+           frames = queue:from_list([Frame]),
+           end_stream = ?IS_FLAG(FH#frame_header.flags, ?FLAG_END_STREAM),
+           end_headers = ?IS_FLAG(FH#frame_header.flags, ?FLAG_END_HEADERS),
+           stream_id = StreamId
+          },
+
+    maybe_hpack(ContinuationState, NewConn);
 route_frame(F={H=#frame_header{
                     stream_id=StreamId,
                     type=?CONTINUATION
@@ -645,52 +636,17 @@ route_frame(F={H=#frame_header{
             #connection{
                continuation = #continuation_state{
                                  frames = CFQ,
-                                 stream_id = StreamId,
-                                 end_stream = EndStream,
-                                 type=ContType
+                                 stream_id = StreamId
                                 } = Cont
               }=Conn) ->
     lager:debug("[~p] Received CONTINUATION Frame for Stream ~p",
                 [Conn#connection.type, StreamId]),
 
-    Streams=Conn#connection.streams,
-    Stream = get_stream(StreamId, Streams),
-
-    Queue = queue:in(F, CFQ),
-
-    case ?IS_FLAG(H#frame_header.flags, ?FLAG_END_HEADERS) of
-        true ->
-            HeadersBin = http2_frame_headers:from_frames(queue:to_list(Queue)),
-            DecodeContext = Conn#connection.decode_context,
-            case hpack:decode(HeadersBin, DecodeContext) of
-                {ok, {Headers, NewDecodeContext}} ->
-
-                    case ContType of
-                        headers ->
-                            http2_stream:recv_h(Stream#stream.pid, Headers);
-                        push_promise ->
-                            http2_stream:recv_pp(Stream#stream.pid, Headers)
-                    end,
-                    case EndStream of
-                        true ->
-                            http2_stream:recv_es(Stream#stream.pid);
-                        false ->
-                            ok
-                    end,
-                    {next_state, connected,
-                     Conn#connection{
-                       decode_context=NewDecodeContext,
-                       continuation=undefined
-                      }};
-                {error, compression_error} ->
-                    go_away(?COMPRESSION_ERROR, Conn)
-            end;
-        false ->
-            {next_state, continuation,
-             Conn#connection{
-               continuation=Cont#continuation_state{frames = Queue}
-              }}
-    end;
+    maybe_hpack(Cont#continuation_state{
+                  frames=queue:in(F, CFQ),
+                  end_headers=?IS_FLAG(H#frame_header.flags, ?FLAG_END_HEADERS)
+                 },
+                Conn);
 
 route_frame({H, _Payload},
             #connection{}=Conn)
@@ -728,19 +684,14 @@ route_frame(
             {next_state, connected, Conn}
     end;
 route_frame({H=#frame_header{
-                  stream_id=StreamId,
-                  flags=Flags
+                  stream_id=StreamId
                  },
              #push_promise{
                 promised_stream_id=PSID
                 }}=Frame,
-            #connection{
-               decode_context=DecodeContext
-              }=Conn)
+            #connection{}=Conn)
     when H#frame_header.type == ?PUSH_PROMISE ->
 
-    %% TODO OOOOOOOOOOOPS! PUSH_PROMISE can have continuations too!
-    %% will need rework after this refactor, issue #10
     lager:debug("[~p] Received PUSH_PROMISE Frame on Stream ~p for Stream ~p",
                 [Conn#connection.type, StreamId, PSID]),
 
@@ -752,32 +703,19 @@ route_frame({H=#frame_header{
 
     lager:debug("[~p] recv(~p, {~p, ~p})",
                 [Conn#connection.type, Frame, StreamId, Conn]),
-    case ?IS_FLAG(Flags, ?FLAG_END_HEADERS) of
-        true ->
-            HeadersBin = http2_frame_headers:from_frames([Frame]),
-            case hpack:decode(HeadersBin, DecodeContext) of
-                {ok, {Headers, NewDecodeContext}} ->
 
-                    http2_stream:recv_pp(New#stream.pid, Headers),
+    Continuation = #continuation_state{
+                      stream_id=StreamId,
+                      type=push_promise,
+                      frames = queue:in(Frame, queue:new()),
+                      end_headers=?IS_FLAG(H#frame_header.flags, ?FLAG_END_HEADERS),
+                      promised_id=PSID
+                     },
 
-                    {next_state, connected,
-                     Conn#connection{
-                       decode_context=NewDecodeContext,
-                       streams=[New|Streams]}};
-                {error, compression_error} ->
-                    go_away(?COMPRESSION_ERROR, Conn)
-            end;
-        false ->
-            {next_state, continuation,
-             Conn#connection{
-               continuation = #continuation_state{
-                                 stream_id = StreamId,
-                                 frames = queue:from_list([Frame]),
-                                 type = push_promise
-                                 },
-               streams=[New|Streams]
-              }}
-    end;
+    maybe_hpack(Continuation,
+                Conn#connection{
+                  streams = [New|Streams]
+                 });
 
 %% PING
 
@@ -1536,3 +1474,51 @@ new_stream_(StreamId, NotifyPid, Conn) ->
                   },
     lager:debug("NewStream ~p", [NewStream]),
     NewStream.
+
+-spec maybe_hpack(#continuation_state{}, connection()) ->
+                         {next_state, atom(), connection()}.
+maybe_hpack(Continuation, Conn)
+  when Continuation#continuation_state.end_headers ->
+    Stream = get_stream(Continuation#continuation_state.stream_id,
+                        Conn#connection.streams),
+
+    HeadersBin = http2_frame_headers:from_frames(
+                   queue:to_list(Continuation#continuation_state.frames)),
+    case hpack:decode(HeadersBin, Conn#connection.decode_context) of
+        {error, compression_error} ->
+            go_away(?COMPRESSION_ERROR, Conn);
+        {ok, {Headers, NewDecodeContext}} ->
+            case Continuation#continuation_state.type of
+                headers ->
+                    %% If this returns 'trailers' then it had better
+                    %% also be end_stream
+                    case {
+                      http2_stream:recv_h(Stream#stream.pid, Headers),
+                      Continuation#continuation_state.end_stream
+                      } of
+                        {trailers, false} ->
+                            rst_stream(Stream#stream.id, ?PROTOCOL_ERROR, Conn);
+                        _ -> ok
+                    end;
+                push_promise ->
+                    Promised = get_stream(Continuation#continuation_state.promised_id,
+                                          Conn#connection.streams),
+                    http2_stream:recv_pp(Promised#stream.pid, Headers)
+            end,
+            case Continuation#continuation_state.end_stream of
+                true ->
+                    http2_stream:recv_es(Stream#stream.pid);
+                false ->
+                    ok
+            end,
+            {next_state, connected,
+             Conn#connection{
+               decode_context=NewDecodeContext,
+               continuation=undefined
+              }}
+    end;
+maybe_hpack(Continuation, Conn) ->
+    {next_state, continuation,
+     Conn#connection{
+       continuation = Continuation
+      }}.

--- a/test/http2_spec_6_1_SUITE.erl
+++ b/test/http2_spec_6_1_SUITE.erl
@@ -45,19 +45,6 @@ sends_data_with_invalid_pad_length(_Config) ->
         }
      },
 
-
-%    L = byte_size(Data)+1,
-%    PaddedData = <<L,Data/binary>>,
-%    DF = {
-%      #frame_header{
-%         stream_id=1,
-%         flags=?FLAG_END_STREAM bor ?FLAG_PADDED
-%        },
-%      #data{
-%         data=PaddedData
-%        }
-%     },
-
     http2c:send_unaltered_frames(Client, [HF]),
     http2c:send_binary(
       Client,

--- a/test/http2_spec_8_1_SUITE.erl
+++ b/test/http2_spec_8_1_SUITE.erl
@@ -73,10 +73,10 @@ sends_second_headers_with_no_end_stream(_Config) ->
 
     http2c:send_unaltered_frames(Client, [HF, Data, TF]),
 
-    Resp = http2c:wait_for_n_frames(Client, 1, 1),
+    Resp = http2c:wait_for_n_frames(Client, 1, 2),
     ct:pal("Resp: ~p", [Resp]),
-    ?assertEqual(1, length(Resp)),
-    [{Header, Payload}] = Resp,
+    ?assertEqual(2, length(Resp)),
+    [_WindowUpdate,{Header, Payload}] = Resp,
     ?assertEqual(?RST_STREAM, Header#frame_header.type),
     ?assertEqual(?PROTOCOL_ERROR, Payload#rst_stream.error_code),
     ok.

--- a/test/http2_spec_8_1_SUITE.erl
+++ b/test/http2_spec_8_1_SUITE.erl
@@ -1,0 +1,82 @@
+-module(http2_spec_8_1_SUITE).
+
+-include("http2.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-compile([export_all]).
+
+all() ->
+    [
+     sends_second_headers_with_no_end_stream
+    ].
+
+init_per_suite(Config) ->
+%%    application:ensure_started(crypto),
+    chatterbox_test_buddy:start(Config).
+
+end_per_suite(Config) ->
+    chatterbox_test_buddy:stop(Config),
+    ok.
+
+sends_second_headers_with_no_end_stream(_Config) ->
+
+    {ok, Client} = http2c:start_link(),
+
+    RequestHeaders =
+        [
+         {<<":method">>, <<"GET">>},
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>},
+         {<<"trailer">>, <<"x-test">>}
+        ],
+
+    {ok, {HeadersBin, EC}} = hpack:encode(RequestHeaders, hpack:new_context()),
+
+    HF = {
+      #frame_header{
+         stream_id=1,
+         flags=?FLAG_END_HEADERS
+        },
+      #headers{
+         block_fragment=HeadersBin
+        }
+     },
+
+    Data = {
+      #frame_header{
+         stream_id=1,
+         length=2
+        },
+      #data{
+         data= <<"hi">>
+        }
+     },
+
+    RequestTrailers =
+        [
+         {<<"x-test">>, <<"ok">>}
+        ],
+    {ok, {TrailersBin, _EC2}} = hpack:encode(RequestTrailers, EC),
+    TF = {
+      #frame_header{
+         stream_id=1,
+         flags=?FLAG_END_HEADERS
+        },
+      #headers{
+         block_fragment=TrailersBin
+        }
+     },
+
+    http2c:send_unaltered_frames(Client, [HF, Data, TF]),
+
+    Resp = http2c:wait_for_n_frames(Client, 1, 1),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(1, length(Resp)),
+    [{Header, Payload}] = Resp,
+    ?assertEqual(?RST_STREAM, Header#frame_header.type),
+    ?assertEqual(?PROTOCOL_ERROR, Payload#rst_stream.error_code),
+    ok.

--- a/test/http2c.erl
+++ b/test/http2c.erl
@@ -96,6 +96,7 @@ wait_for_n_frames(Pid, StreamId, N, Attempts, Acc) ->
 
     case length(Frames) >= N of
         true ->
+            lager:info("Frames: ~p ~p", [N, Frames]),
             ?assertEqual(N, length(Frames)),
             Frames;
         false ->


### PR DESCRIPTION
```
  8.1. HTTP Request/Response Exchange
    × Sends a second HEADERS frame without the END_STREAM flag
      - The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.
        Expected: GOAWAY frame (ErrorCode: PROTOCOL_ERROR)
                  RST_STREAM frame (ErrorCode: PROTOCOL_ERROR)
                  Connection close
          Actual: WINDOW_UPDATE frame (Length: 4, Flags: 0)
```