### PR TITLE
8.1.2.1. Pseudo-Header Fields: Sends a HEADERS frame that contains a pseudo-header field that appears in a header block after a regular header field

### DIFF
--- a/test/http2_spec_8_1_SUITE.erl
+++ b/test/http2_spec_8_1_SUITE.erl
@@ -8,7 +8,8 @@
 all() ->
     [
      sends_second_headers_with_no_end_stream,
-     sends_uppercase_headers
+     sends_uppercase_headers,
+     sends_pseudo_after_regular
     ].
 
 init_per_suite(Config) ->
@@ -94,6 +95,39 @@ sends_uppercase_headers(_Config) ->
          {<<"accept-encoding">>, <<"gzip, deflate">>},
          {<<"user-agent">>, <<"chattercli/0.0.1 :D">>},
          {<<"X-TEST">>, <<"test">>}
+        ],
+
+    {ok, {HeadersBin, _EC}} = hpack:encode(RequestHeaders, hpack:new_context()),
+    HF = {
+      #frame_header{
+         stream_id=1,
+         flags=?FLAG_END_HEADERS
+        },
+      #headers{
+         block_fragment=HeadersBin
+        }
+     },
+    http2c:send_unaltered_frames(Client, [HF]),
+
+    Resp = http2c:wait_for_n_frames(Client, 1, 1),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(1, length(Resp)),
+    [{Header, Payload}] = Resp,
+    ?assertEqual(?RST_STREAM, Header#frame_header.type),
+    ?assertEqual(?PROTOCOL_ERROR, Payload#rst_stream.error_code),
+    ok.
+
+sends_pseudo_after_regular(_Config) ->
+    {ok, Client} = http2c:start_link(),
+    RequestHeaders =
+        [
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<":method">>, <<"GET">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
         ],
 
     {ok, {HeadersBin, _EC}} = hpack:encode(RequestHeaders, hpack:new_context()),


### PR DESCRIPTION
```
      8.1.2.1. Pseudo-Header Fields
        × Sends a HEADERS frame that contains a pseudo-header field that appears in a header block after a regular header field
          - The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.
            Expected: GOAWAY frame (ErrorCode: PROTOCOL_ERROR)
                      RST_STREAM frame (ErrorCode: PROTOCOL_ERROR)
                      Connection close
              Actual: DATA frame (Length: 16, Flags: 1)
```