### PR TITLE
send partial bodies

### DIFF
--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -16,6 +16,7 @@
 -export([
          send_headers/3,
          send_body/3,
+         send_body/4,
          is_push/1,
          new_stream/1,
          new_stream/2,
@@ -99,6 +100,11 @@
 }).
 
 -type connection() :: #connection{}.
+
+-type send_body_option() :: {send_rst_stream, boolean()}.
+-type send_body_opts() :: [send_body_option()].
+
+-export_type([send_body_option/0, send_body_opts/0]).
 
 -spec start_client_link(gen_tcp | ssl,
                         inet:ip_address() | inet:hostname(),
@@ -210,6 +216,12 @@ send_headers(Pid, StreamId, Headers) ->
 send_body(Pid, StreamId, Body) ->
     gen_fsm:send_all_state_event(Pid, {send_body, StreamId, Body}),
     ok.
+-spec send_body(pid(), stream_id(), binary(), send_body_opts()) -> ok.
+send_body(Pid, StreamId, Body, _Opts) ->
+    gen_fsm:send_all_state_event(Pid, {send_body, StreamId, Body}),
+    ok.
+
+
 
 -spec get_peer(pid()) ->
     {ok, {inet:ip_address(), inet:port_number()}} | {error, term()}.

--- a/test/client_server_SUITE.erl
+++ b/test/client_server_SUITE.erl
@@ -144,5 +144,5 @@ send_body_opts(_Config) ->
     {ok, {ResponseHeaders, ResponseBody}} = http2_client:sync_request(Client, RequestHeaders, <<>>),
     ct:pal("Response Headers: ~p", [ResponseHeaders]),
     ct:pal("Response Body: ~p", [ResponseBody]),
-    ?assertEqual(ExpectedResponseBody, ResponseBody),
+    ?assertEqual(ExpectedResponseBody, iolist_to_binary(ResponseBody)),
     ok.

--- a/test/client_server_SUITE.erl
+++ b/test/client_server_SUITE.erl
@@ -7,13 +7,15 @@
 all() ->
     [
      {group, default_handler},
-     {group, peer_handler}
+     {group, peer_handler},
+     {group, double_body_handler}
     ].
 
 groups() -> [{default_handler,  [complex_request,
                                  upgrade_tcp_connection,
                                  basic_push]},
-             {peer_handler, [get_peer_in_handler]}
+             {peer_handler, [get_peer_in_handler]},
+             {double_body_handler, [send_body_opts]}
             ].
 
 init_per_suite(Config) ->
@@ -23,11 +25,16 @@ init_per_group(default_handler, Config) ->
     %% We'll start up a chatterbox server once, with this data_dir.
     NewConfig = [{www_root, data_dir},{initial_window_size,99999999}|Config],
     chatterbox_test_buddy:start(NewConfig);
-init_per_group(_, Config) ->
-    NewConfig = [{stream_callback_mod, peer_test_handler},
+init_per_group(double_body_handler, Config) ->
+    NewConfig = [{stream_callback_mod, double_body_handler},
                  {initial_window_size,99999999}|Config],
     chatterbox_test_buddy:start(NewConfig),
-    Config.
+    Config;
+init_per_group(peer_handler, Config) ->
+    NewConfig = [{stream_callback_mod, peer_test_handler},
+                 {initial_window_size,99999999}|Config],
+    chatterbox_test_buddy:start(NewConfig);
+init_per_group(_, Config) -> Config.
 
 init_per_testcase(_, Config) ->
     Config.
@@ -117,4 +124,25 @@ get_peer_in_handler(_Config) ->
     {ok, {ResponseHeaders, ResponseBody}} = http2_client:sync_request(Client, RequestHeaders, <<>>),
     ct:pal("Response Headers: ~p", [ResponseHeaders]),
     ct:pal("Response Body: ~p", [ResponseBody]),
+    ok.
+
+send_body_opts(_Config) ->
+    {ok, Client} = http2_client:start_link(),
+    RequestHeaders =
+        [
+         {<<":method">>, <<"GET">>},
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ],
+
+    ExpectedResponseBody = <<"BodyPart1\nBodyPart2">>,
+
+    {ok, {ResponseHeaders, ResponseBody}} = http2_client:sync_request(Client, RequestHeaders, <<>>),
+    ct:pal("Response Headers: ~p", [ResponseHeaders]),
+    ct:pal("Response Body: ~p", [ResponseBody]),
+    ?assertEqual(ExpectedResponseBody, ResponseBody),
     ok.

--- a/test/double_body_handler.erl
+++ b/test/double_body_handler.erl
@@ -45,7 +45,7 @@ on_request_end_stream(State=#state{conn_pid=ConnPid,
                       ],
     http2_connection:send_headers(ConnPid, StreamId, ResponseHeaders),
     http2_connection:send_body(ConnPid, StreamId, <<"BodyPart1\n">>,
-                               [{send_rst_stream, false}]),
+                               [{send_end_stream, false}]),
     http2_connection:send_body(ConnPid, StreamId, <<"BodyPart2">>),
     {ok, State}.
 

--- a/test/double_body_handler.erl
+++ b/test/double_body_handler.erl
@@ -1,0 +1,51 @@
+-module(double_body_handler).
+
+-include_lib("chatterbox/include/http2.hrl").
+
+-behaviour(http2_stream).
+
+-export([
+         init/2,
+         on_receive_request_headers/2,
+         on_send_push_promise/2,
+         on_receive_request_data/2,
+         on_request_end_stream/1
+        ]).
+
+-record(state, {conn_pid :: pid(),
+                stream_id :: integer()
+               }).
+
+-spec init(pid(), integer()) -> {ok, any()}.
+init(ConnPid, StreamId) -> {ok, #state{conn_pid=ConnPid,
+                                       stream_id=StreamId}}.
+
+-spec on_receive_request_headers(
+            Headers :: hpack:headers(),
+            CallbackState :: any()) -> {ok, NewState :: any()}.
+on_receive_request_headers(_Headers, State) -> {ok, State}.
+
+-spec on_send_push_promise(
+            Headers :: hpack:headers(),
+            CallbackState :: any()) -> {ok, NewState :: any()}.
+on_send_push_promise(_Headers, State) -> {ok, State}.
+
+-spec on_receive_request_data(
+            iodata(),
+            CallbackState :: any())-> {ok, NewState :: any()}.
+on_receive_request_data(_Data, State) -> {ok, State}.
+
+-spec on_request_end_stream(
+            CallbackState :: any()) ->
+    {ok, NewState :: any()}.
+on_request_end_stream(State=#state{conn_pid=ConnPid,
+                                   stream_id=StreamId}) ->
+    ResponseHeaders = [
+                       {<<":status">>,<<"200">>}
+                      ],
+    http2_connection:send_headers(ConnPid, StreamId, ResponseHeaders),
+    http2_connection:send_body(ConnPid, StreamId, <<"BodyPart1\n">>,
+                               [{send_rst_stream, false}]),
+    http2_connection:send_body(ConnPid, StreamId, <<"BodyPart2">>),
+    {ok, State}.
+

--- a/test/flow_control_handler.erl
+++ b/test/flow_control_handler.erl
@@ -1,0 +1,55 @@
+-module(flow_control_handler).
+
+-include_lib("chatterbox/include/http2.hrl").
+
+-define(SEND_BYTES, 68).
+
+-behaviour(http2_stream).
+
+-export([
+         init/2,
+         on_receive_request_headers/2,
+         on_send_push_promise/2,
+         on_receive_request_data/2,
+         on_request_end_stream/1
+        ]).
+
+-record(state, {conn_pid :: pid(),
+                stream_id :: integer()
+               }).
+
+-spec init(pid(), integer()) -> {ok, any()}.
+init(ConnPid, StreamId) ->
+    {ok, #state{conn_pid=ConnPid,
+                stream_id=StreamId}}.
+
+-spec on_receive_request_headers(
+            Headers :: hpack:headers(),
+            CallbackState :: any()) -> {ok, NewState :: any()}.
+on_receive_request_headers(_Headers, State) -> {ok, State}.
+
+-spec on_send_push_promise(
+            Headers :: hpack:headers(),
+            CallbackState :: any()) -> {ok, NewState :: any()}.
+on_send_push_promise(_Headers, State) -> {ok, State}.
+
+-spec on_receive_request_data(
+            iodata(),
+            CallbackState :: any())-> {ok, NewState :: any()}.
+on_receive_request_data(_Data, State) -> {ok, State}.
+
+-spec on_request_end_stream(
+            CallbackState :: any()) ->
+    {ok, NewState :: any()}.
+on_request_end_stream(State=#state{conn_pid=ConnPid,
+                                   stream_id=StreamId}) ->
+    ResponseHeaders = [
+                       {<<":status">>,<<"200">>}
+                      ],
+    http2_connection:send_headers(ConnPid, StreamId, ResponseHeaders),
+    http2_connection:send_body(ConnPid, StreamId, crypto:rand_bytes(?SEND_BYTES),
+                               [{send_end_stream, false}]),
+    timer:sleep(200),
+    http2_connection:send_body(ConnPid, StreamId, crypto:rand_bytes(?SEND_BYTES)),
+    {ok, State}.
+

--- a/test/http2c.erl
+++ b/test/http2c.erl
@@ -138,7 +138,8 @@ init([]) ->
     {_SSH, ServerSettings} = http2_frame:read({Transport, Socket}, 1000),
     http2_frame_settings:ack({Transport, Socket}),
 
-    ClientSettings = #settings{},
+    ClientSettings = chatterbox:settings(client),
+    lager:debug("[client] settings: ~p", [http2_settings:to_proplist(ClientSettings)]),
 
     BinToSend = http2_frame_settings:send(#settings{}, ClientSettings),
     Transport:send(Socket, BinToSend),


### PR DESCRIPTION
adds `http2_connection:send_body/4`, which can take an arg
`{send_rst_stream, false}`. This lets handlers call send_body
multiple times instead of needing to buffer output