### PR TITLE
Deadlocks in callbacks

### DIFF
--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -580,13 +580,11 @@ route_frame({#frame_header{type=?HEADERS}=FH, _Payload}=Frame,
 
     %% Four things could be happening here.
 
-    %% If we're a server, these are either Request Headers or Request
-    %% Trailers
+    %% If we're a server, these are either request headers or request
+    %% trailers
 
-    %% If we're a client, these are Response Headers or Response
-    %% Headers, but the response is to a Push Promise
-
-
+    %% If we're a client, these are either headers in response to a
+    %% client request, or headers in response to a push promise
 
     {ContinuationType, NewConn} =
         case {get_stream(StreamId, Streams), Conn#connection.type} of

--- a/test/peer_test_handler.erl
+++ b/test/peer_test_handler.erl
@@ -1,0 +1,55 @@
+-module(peer_test_handler).
+
+-include_lib("chatterbox/include/http2.hrl").
+
+-behaviour(http2_stream).
+
+-export([
+         init/2,
+         on_receive_request_headers/2,
+         on_send_push_promise/2,
+         on_receive_request_data/2,
+         on_request_end_stream/1
+        ]).
+
+-record(state, {conn_pid :: pid(),
+                stream_id :: integer(),
+                peer = undefined :: undefined | {inet:ip_addres(),
+                                                 inet:port_number()}
+               }).
+
+-spec init(pid(), integer()) -> {ok, any()}.
+init(ConnPid, StreamId) -> {ok, #state{conn_pid=ConnPid,
+                                       stream_id=StreamId}}.
+
+-spec on_receive_request_headers(
+            Headers :: hpack:headers(),
+            CallbackState :: any()) -> {ok, NewState :: any()}.
+on_receive_request_headers(_Headers, State=#state{conn_pid=ConnPid}) ->
+    {ok, Peer} = http2_connection:get_peer(ConnPid),
+    State#state{peer=Peer}.
+
+-spec on_send_push_promise(
+            Headers :: hpack:headers(),
+            CallbackState :: any()) -> {ok, NewState :: any()}.
+on_send_push_promise(_Headers, State) -> {ok, State}.
+
+-spec on_receive_request_data(
+            iodata(),
+            CallbackState :: any())-> {ok, NewState :: any()}.
+on_receive_request_data(_Data, State) -> {ok, State}.
+
+-spec on_request_end_stream(
+            CallbackState :: any()) ->
+    {ok, NewState :: any()}.
+on_request_end_stream(State=#state{conn_pid=ConnPid,
+                                   stream_id=StreamId,
+                                   peer={Address, Port}}) ->
+    Body = list_to_binary(io_lib:format("Address: ~p, Port: ~p", [Address, Port])),
+    ResponseHeaders = [
+                       {<<":status">>,<<"200">>}
+                      ],
+    http2_connection:send_headers(ConnPid, StreamId, ResponseHeaders),
+    http2_connection:send_body(ConnPid, StreamId, Body),
+    {ok, State}.
+

--- a/test/peer_test_handler.erl
+++ b/test/peer_test_handler.erl
@@ -27,7 +27,7 @@ init(ConnPid, StreamId) -> {ok, #state{conn_pid=ConnPid,
             CallbackState :: any()) -> {ok, NewState :: any()}.
 on_receive_request_headers(_Headers, State=#state{conn_pid=ConnPid}) ->
     {ok, Peer} = http2_connection:get_peer(ConnPid),
-    State#state{peer=Peer}.
+    {ok, State#state{peer=Peer}}.
 
 -spec on_send_push_promise(
             Headers :: hpack:headers(),
@@ -52,4 +52,3 @@ on_request_end_stream(State=#state{conn_pid=ConnPid,
     http2_connection:send_headers(ConnPid, StreamId, ResponseHeaders),
     http2_connection:send_body(ConnPid, StreamId, Body),
     {ok, State}.
-


### PR DESCRIPTION
When calling a blocking function such as `http2_connection:get_peer/1` from within a callback module, if the initial call to the stream was done synchronously (via `http2_stream:recv_h` iirc) in a dispatch, the callback module's function calls are done within that synchronous context.

This in turns means that any call to the connection that is blocking ends up in a deadlock and everything fails after a timeout.