### PR TITLE
8.1. HTTP Request/Response Exchange: Sends a HEADERS frame as HEAD request

### DIFF
--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -1620,6 +1620,8 @@ validate_pseudos(_, DoneWithPseudos) ->
     lists:all(
       fun({<<$:, _/binary>>, _}) ->
               false;
+         ({<<"connection">>, _}) ->
+              false;
          (_) -> true
       end,
       DoneWithPseudos)

--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -1606,17 +1606,30 @@ no_upper_names(Headers) ->
       end,
      Headers).
 
-validate_pseudos(request, [{<<":path">>,_V}|Tail]) ->
-    validate_pseudos(request, Tail);
-validate_pseudos(request, [{<<":method">>,_V}|Tail]) ->
-    validate_pseudos(request, Tail);
-validate_pseudos(request, [{<<":scheme">>,_V}|Tail]) ->
-    validate_pseudos(request, Tail);
-validate_pseudos(request, [{<<":authority">>,_V}|Tail]) ->
-    validate_pseudos(request, Tail);
-validate_pseudos(response, [{<<":status">>,_V}|Tail]) ->
-    validate_pseudos(response, Tail);
-validate_pseudos(_, DoneWithPseudos) ->
+validate_pseudos(Type, Headers) ->
+    validate_pseudos(Type, Headers, #{}).
+
+validate_pseudos(request, [{<<":path">>,_V}|_Tail], #{<<":path">> := true }) ->
+    false;
+validate_pseudos(request, [{<<":path">>,_V}|Tail], Found) ->
+    validate_pseudos(request, Tail, Found#{<<":path">> => true});
+validate_pseudos(request, [{<<":method">>,_V}|_Tail], #{<<":method">> := true }) ->
+    false;
+validate_pseudos(request, [{<<":method">>,_V}|Tail], Found) ->
+    validate_pseudos(request, Tail, Found#{<<":method">> => true});
+validate_pseudos(request, [{<<":scheme">>,_V}|_Tail], #{<<":scheme">> := true }) ->
+    false;
+validate_pseudos(request, [{<<":scheme">>,_V}|Tail], Found) ->
+    validate_pseudos(request, Tail, Found#{<<":scheme">> => true});
+validate_pseudos(request, [{<<":authority">>,_V}|_Tail], #{<<":authority">> := true }) ->
+    false;
+validate_pseudos(request, [{<<":authority">>,_V}|Tail], Found) ->
+    validate_pseudos(request, Tail, Found#{<<":authority">> => true});
+validate_pseudos(request, [{<<":status">>,_V}|_Tail], #{<<":status">> := true }) ->
+    false;
+validate_pseudos(response, [{<<":status">>,_V}|Tail], Found) ->
+    validate_pseudos(response, Tail, Found#{<<":status">> => true});
+validate_pseudos(_, DoneWithPseudos, _Found) ->
     lists:all(
       fun({<<$:, _/binary>>, _}) ->
               false;

--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -1622,6 +1622,10 @@ validate_pseudos(_, DoneWithPseudos) ->
               false;
          ({<<"connection">>, _}) ->
               false;
+         ({<<"te">>, <<"trailers">>}) ->
+              true;
+         ({<<"te">>, _}) ->
+              false;
          (_) -> true
       end,
       DoneWithPseudos)

--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -15,6 +15,7 @@
 
 -export([
          send_headers/3,
+         send_headers/4,
          send_body/3,
          send_body/4,
          is_push/1,
@@ -102,10 +103,10 @@
 
 -type connection() :: #connection{}.
 
--type send_body_option() :: {send_end_stream, boolean()}.
--type send_body_opts() :: [send_body_option()].
+-type send_option() :: {send_end_stream, boolean()}.
+-type send_opts() :: [send_option()].
 
--export_type([send_body_option/0, send_body_opts/0]).
+-export_type([send_option/0, send_opts/0]).
 
 -spec start_client_link(gen_tcp | ssl,
                         inet:ip_address() | inet:hostname(),
@@ -210,14 +211,19 @@ send_frame(Pid, Frame) ->
 
 -spec send_headers(pid(), stream_id(), hpack:headers()) -> ok.
 send_headers(Pid, StreamId, Headers) ->
-    gen_fsm:send_all_state_event(Pid, {send_headers, StreamId, Headers}),
+    gen_fsm:send_all_state_event(Pid, {send_headers, StreamId, Headers, []}),
+    ok.
+
+-spec send_headers(pid(), stream_id(), hpack:headers(), send_opts()) -> ok.
+send_headers(Pid, StreamId, Headers, Opts) ->
+    gen_fsm:send_all_state_event(Pid, {send_headers, StreamId, Headers, Opts}),
     ok.
 
 -spec send_body(pid(), stream_id(), binary()) -> ok.
 send_body(Pid, StreamId, Body) ->
     gen_fsm:send_all_state_event(Pid, {send_body, StreamId, Body, []}),
     ok.
--spec send_body(pid(), stream_id(), binary(), send_body_opts()) -> ok.
+-spec send_body(pid(), stream_id(), binary(), send_opts()) -> ok.
 send_body(Pid, StreamId, Body, Opts) ->
     gen_fsm:send_all_state_event(Pid, {send_body, StreamId, Body, Opts}),
     ok.
@@ -977,7 +983,7 @@ handle_event({send_window_update, Size},
      Conn#connection{
        recv_window_size=CRWS+Size
       }};
-handle_event({send_headers, StreamId, Headers},
+handle_event({send_headers, StreamId, Headers, Opts},
              StateName,
              #connection{
                 encode_context=EncodeContext,
@@ -988,13 +994,17 @@ handle_event({send_headers, StreamId, Headers},
     lager:debug("[~p] {send headers, ~p, ~p}",
                 [Conn#connection.type, StreamId, Headers]),
     Stream = get_stream(StreamId, Streams),
+    StreamComplete = proplists:get_value(send_end_stream, Opts, false),
 
-    %% TODO: This is set up in a way that assumes the header frame is
-    %% smaller than MAX_FRAME_SIZE. Will need to split that out into
-    %% continuation frames,but now will definitely be a
-    %% FRAME_SIZE_ERROR
-    {HeaderFrame, NewContext} = http2_frame_headers:to_frame(Stream#stream.id, Headers, EncodeContext),
-    sock:send(Socket, http2_frame:to_binary(HeaderFrame)),
+    {FramesToSend, NewContext} =
+        http2_frame_headers:to_frames(Stream#stream.id,
+                                      Headers,
+                                      EncodeContext,
+                                      Conn#connection.send_settings#settings.max_frame_size,
+                                      StreamComplete
+                                     ),
+
+    [ sock:send(Socket, http2_frame:to_binary(Frame)) || Frame <- FramesToSend],
     http2_stream:send_h(Stream#stream.pid, Headers),
 
     {next_state, StateName,

--- a/test/http2_spec_5_1_SUITE.erl
+++ b/test/http2_spec_5_1_SUITE.erl
@@ -74,9 +74,14 @@ client_sends_even_stream_id(_Config) ->
          {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
         ],
 
-    {F, _} = http2_frame_headers:to_frame(2, RequestHeaders, hpack:new_context()),
+    {H, _} =
+        http2_frame_headers:to_frames(2,
+                                      RequestHeaders,
+                                      hpack:new_context(),
+                                      16384,
+                                      false),
 
-    http2c:send_unaltered_frames(Client, [F]),
+    http2c:send_unaltered_frames(Client, H),
 
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
     ct:pal("Resp: ~p", [Resp]),

--- a/test/http2_spec_8_1_SUITE.erl
+++ b/test/http2_spec_8_1_SUITE.erl
@@ -14,7 +14,8 @@ all() ->
      sends_invalid_pseudo,
      sends_response_pseudo_with_request,
      sends_connection_header,
-     sends_bad_TE_header
+     sends_bad_TE_header,
+     sends_double_pseudo
     ].
 
 init_per_suite(Config) ->
@@ -214,3 +215,56 @@ sends_bad_TE_header(_Config) ->
          {<<"user-agent">>, <<"chattercli/0.0.1 :D">>},
          {<<"te">>, <<"trailers, deflate">>}
         ]).
+
+sends_double_pseudo(_Config) ->
+    test_rst_stream(
+        [
+         {<<":path">>, <<"/">>},
+         {<<":path">>, <<"/">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<":method">>, <<"GET">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ]),
+
+    test_rst_stream(
+        [
+         {<<":path">>, <<"/">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<":method">>, <<"GET">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ]),
+
+    test_rst_stream(
+        [
+         {<<":path">>, <<"/">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<":method">>, <<"GET">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ]),
+
+    test_rst_stream(
+        [
+         {<<":path">>, <<"/">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<":method">>, <<"GET">>},
+         {<<":method">>, <<"GET">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ]),
+
+
+
+    ok.

--- a/test/http2_spec_8_1_SUITE.erl
+++ b/test/http2_spec_8_1_SUITE.erl
@@ -13,7 +13,8 @@ all() ->
      sends_pseudo_after_regular,
      sends_invalid_pseudo,
      sends_response_pseudo_with_request,
-     sends_connection_header
+     sends_connection_header,
+     sends_bad_TE_header
     ].
 
 init_per_suite(Config) ->
@@ -199,4 +200,17 @@ sends_connection_header(_Config) ->
          {<<"accept-encoding">>, <<"gzip, deflate">>},
          {<<"user-agent">>, <<"chattercli/0.0.1 :D">>},
          {<<"connection">>, <<"keep-alive">>}
+        ]).
+
+sends_bad_TE_header(_Config) ->
+    test_rst_stream(
+        [
+         {<<":path">>, <<"/">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<":method">>, <<"GET">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>},
+         {<<"te">>, <<"trailers, deflate">>}
         ]).

--- a/test/http2_spec_8_1_SUITE.erl
+++ b/test/http2_spec_8_1_SUITE.erl
@@ -7,19 +7,50 @@
 
 all() ->
     [
+     sends_head_request,
      sends_second_headers_with_no_end_stream,
      sends_uppercase_headers,
      sends_pseudo_after_regular,
      sends_invalid_pseudo,
-     sends_response__pseudo_with_request
+     sends_response_pseudo_with_request
     ].
 
 init_per_suite(Config) ->
-%%    application:ensure_started(crypto),
     chatterbox_test_buddy:start(Config).
 
 end_per_suite(Config) ->
     chatterbox_test_buddy:stop(Config),
+    ok.
+
+sends_head_request(_Config) ->
+    {ok, Client} = http2c:start_link(),
+    RequestHeaders =
+        [
+         {<<":method">>, <<"HEAD">>},
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ],
+    {ok, {HeadersBin, _EC}} = hpack:encode(RequestHeaders, hpack:new_context()),
+    HF = {
+      #frame_header{
+         stream_id=1,
+         flags=?FLAG_END_HEADERS bor ?FLAG_END_STREAM
+        },
+      #headers{
+         block_fragment=HeadersBin
+        }
+     },
+    http2c:send_unaltered_frames(Client, [HF]),
+
+    Resp = http2c:wait_for_n_frames(Client, 1, 1),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(1, length(Resp)),
+    [{Header, _Payload}] = Resp,
+    ?assertEqual(?HEADERS, Header#frame_header.type),
     ok.
 
 sends_second_headers_with_no_end_stream(_Config) ->
@@ -122,7 +153,7 @@ sends_invalid_pseudo(_Config) ->
          {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
         ]).
 
-sends_response__pseudo_with_request(_Config) ->
+sends_response_pseudo_with_request(_Config) ->
     test_rst_stream(
         [
          {<<":status">>, <<"200">>},

--- a/test/http2_spec_8_1_SUITE.erl
+++ b/test/http2_spec_8_1_SUITE.erl
@@ -12,7 +12,8 @@ all() ->
      sends_uppercase_headers,
      sends_pseudo_after_regular,
      sends_invalid_pseudo,
-     sends_response_pseudo_with_request
+     sends_response_pseudo_with_request,
+     sends_connection_header
     ].
 
 init_per_suite(Config) ->
@@ -186,3 +187,16 @@ test_rst_stream(RequestHeaders) ->
     ?assertEqual(?RST_STREAM, Header#frame_header.type),
     ?assertEqual(?PROTOCOL_ERROR, Payload#rst_stream.error_code),
     ok.
+
+sends_connection_header(_Config) ->
+    test_rst_stream(
+        [
+         {<<":path">>, <<"/">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<":method">>, <<"GET">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>},
+         {<<"connection">>, <<"keep-alive">>}
+        ]).


### PR DESCRIPTION
```
8.1. HTTP Request/Response Exchange
    × Sends a HEADERS frame as HEAD request
      - The endpoint should respond with no DATA frame or empty DATA frame.
        Expected: HEADERS frame (Flags: 1)
                  DATA frame (Length: 0, Flags: 1)
          Actual: DATA frame (Length: 16, Flags: 1)
```