### PR TITLE
8.1.2.6. Malformed Requests and Responses: Sends a HEADERS frame that contains the "content-length" header field which does not equal the sum of the DATA frame payload lengths

### DIFF
--- a/src/chatterbox_static_stream.erl
+++ b/src/chatterbox_static_stream.erl
@@ -150,11 +150,10 @@ on_request_end_stream(State=#cb_static{connection_pid=ConnPid,
     case {Method, HeadersToSend, BodyToSend} of
         {<<"HEAD">>, _, _} ->
                 http2_connection:send_headers(ConnPid, StreamId, HeadersToSend, [{send_end_stream, true}]);
-        {<<"GET">>, _, _} ->
-            http2_connection:send_headers(ConnPid, StreamId, HeadersToSend),
-            http2_connection:send_body(ConnPid, StreamId, BodyToSend);
+        %%{<<"GET">>, _, _} ->
         _ ->
-            lager:error("[chatterbox_static_stream] Unsupported :method (~p)", [Method])
+            http2_connection:send_headers(ConnPid, StreamId, HeadersToSend),
+            http2_connection:send_body(ConnPid, StreamId, BodyToSend)
     end,
 
     {ok, State}.

--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -1598,7 +1598,6 @@ is_valid_headers(Type, Headers) ->
     end.
 
 no_upper_names(Headers) ->
-    lager:error("Headers: ~p", [Headers]),
     lists:all(
       fun({Name,_}) ->
               NameStr = binary_to_list(Name),

--- a/src/http2_stream.erl
+++ b/src/http2_stream.erl
@@ -574,7 +574,7 @@ check_content_length(Stream) ->
         undefined ->
             ok;
         _Other ->
-            case Stream#stream_state.request_body_size =:= ContentLength of
+            case Stream#stream_state.request_body_size =:= binary_to_integer(ContentLength) of
                 true ->
                     ok;
                 false ->


### PR DESCRIPTION
```
      8.1.2.6. Malformed Requests and Responses
        × Sends a HEADERS frame that contains the "content-length" header field which does not equal the sum of the DATA frame payload lengths
          - The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.
            Expected: GOAWAY frame (ErrorCode: PROTOCOL_ERROR)
                      RST_STREAM frame (ErrorCode: PROTOCOL_ERROR)
                      Connection close
              Actual: DATA frame (Length: 16, Flags: 1)
```