### PR TITLE
  5.1. Stream States     × half closed (remote): Sends a HEADERS frame

### DIFF
--- a/test/http2_spec_5_1_SUITE.erl
+++ b/test/http2_spec_5_1_SUITE.erl
@@ -8,6 +8,7 @@
 all() ->
     [
      sends_rst_stream_to_idle,
+     half_closed_remote_sends_headers,
      sends_window_update_to_idle,
      client_sends_even_stream_id
     ].
@@ -37,6 +38,49 @@ sends_rst_stream_to_idle(_Config) ->
     ?assertEqual(1, length(Resp)),
     [{_GoAwayH, GoAway}] = Resp,
     ?PROTOCOL_ERROR = GoAway#goaway.error_code,
+    ok.
+
+half_closed_remote_sends_headers(_Config) ->
+    {ok, Client} = http2c:start_link(),
+    RequestHeaders =
+        [
+         {<<":method">>, <<"GET">>},
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ],
+
+    {H1, EC} =
+        http2_frame_headers:to_frames(1,
+                                      RequestHeaders,
+                                      hpack:new_context(),
+                                      16384,
+                                      true),
+
+    http2c:send_unaltered_frames(Client, H1),
+
+    %% The stream should be half closed remote now
+
+    {H2, _EC2} =
+        http2_frame_headers:to_frames(1,
+                                      RequestHeaders,
+                                      EC,
+                                      16384,
+                                      true),
+
+
+    http2c:send_unaltered_frames(Client, H2),
+
+    Resp = http2c:wait_for_n_frames(Client, 1, 4),
+    ct:pal("Resp: ~p", [Resp]),
+    ?assertEqual(4, length(Resp)),
+    [{_, #headers{}}, {_, #data{}}, {RstStreamH, RstStream}, _] = Resp,
+    ?assertEqual(?RST_STREAM, RstStreamH#frame_header.type),
+    ?assertEqual(?STREAM_CLOSED, RstStream#rst_stream.error_code),
+
     ok.
 
 sends_window_update_to_idle(_Config) ->


### PR DESCRIPTION
```
  5.1. Stream States
    × half closed (remote): Sends a HEADERS frame
      - The endpoint MUST respond with a stream error (Section 5.4.2) of type STREAM_CLOSED.
        Expected: GOAWAY frame (ErrorCode: STREAM_CLOSED)
                  RST_STREAM frame (ErrorCode: STREAM_CLOSED)
                  Connection close
          Actual: RST_STREAM frame (Length: 4, Flags: 0, ErrorCode: PROTOCOL_ERROR)
```