### PR TITLE
Abstracted payload records into types

### DIFF
--- a/include/http2.hrl
+++ b/include/http2.hrl
@@ -90,39 +90,23 @@
     flags = 0   :: non_neg_integer(),
     stream_id   :: stream_id()
     }).
-
 -type frame_header() :: #frame_header{}.
 
--record(data, {
-    data :: iodata()
-  }).
--type data() :: #data{}.
+-type transport() :: gen_tcp | ssl.
+-type socket() :: {gen_tcp, inet:socket()|undefined} | {ssl, ssl:sslsocket()|undefined}.
 
--record(headers, {
-          priority = undefined :: priority() | undefined,
-          block_fragment :: binary()
-}).
--type headers() :: #headers{}.
+-define(PREFACE, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n").
 
--record(priority, {
-    exclusive = 0 :: 0 | 1,
-    stream_id = 0 :: stream_id(),
-    weight = 0 :: non_neg_integer()
-  }).
--type priority() :: #priority{}.
+-define(DEFAULT_INITIAL_WINDOW_SIZE, 65535).
 
--record(rst_stream, {
-          error_code :: error_code()
-}).
--type rst_stream() :: #rst_stream{}.
-
+%% Settings are too big to be part of the data type refactor. We'll
+%% get to it next
 -record(settings, {header_table_size        = 4096,
                    enable_push              = 1,
                    max_concurrent_streams   = unlimited,
                    initial_window_size      = 65535,
                    max_frame_size           = 16384,
                    max_header_list_size     = unlimited}).
--define(DEFAULT_SETTINGS, #settings{}).
 -type settings() :: #settings{}.
 
 -define(SETTINGS_HEADER_TABLE_SIZE,         <<16#1>>).
@@ -140,58 +124,5 @@
                         ?SETTINGS_MAX_HEADER_LIST_SIZE]).
 
 -type setting_name() :: binary().
-
-
 -type settings_property() :: {setting_name(), any()}.
 -type settings_proplist() :: [settings_property()].
-
--record(push_promise, {
-          promised_stream_id :: stream_id(),
-          block_fragment :: binary()
-}).
--type push_promise() :: #push_promise{}.
-
--record(ping, {
-          opaque_data :: binary()
-}).
--type ping() :: #ping{}.
-
--record(goaway, {
-          last_stream_id :: stream_id(),
-          error_code :: error_code(),
-          additional_debug_data = <<>> :: binary()
-}).
--type goaway() :: #goaway{}.
-
--record(window_update, {
-          window_size_increment :: non_neg_integer()
-}).
--type window_update() :: #window_update{}.
-
--record(continuation, {
-          block_fragment :: binary()
-}).
--type continuation() :: #continuation{}.
-
--type payload() :: data()
-                 | headers()
-                 | settings() | {settings, [proplists:property()]}
-                 | priority()
-                 | settings()
-                 | rst_stream()
-                 | push_promise()
-                 | ping()
-                 | goaway()
-                 | window_update()
-                 | continuation()
-                 | binary().
-
--type frame() :: {frame_header(), payload()}.
-
-
--type transport() :: gen_tcp | ssl.
--type socket() :: {gen_tcp, inet:socket()|undefined} | {ssl, ssl:sslsocket()|undefined}.
-
--define(PREFACE, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n").
-
--define(DEFAULT_INITIAL_WINDOW_SIZE, 65535).

--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -63,7 +63,7 @@
 -record(continuation_state, {
           stream_id                 :: stream_id(),
           promised_id = undefined   :: undefined | stream_id(),
-          frames      = queue:new() :: queue:queue(frame()),
+          frames      = queue:new() :: queue:queue(http2_frame:frame()),
           type                      :: headers | push_promise | trailers,
           end_stream  = false       :: boolean(),
           end_headers = false       :: boolean()
@@ -275,7 +275,7 @@ stop(Pid) ->
 listen(timeout, State) ->
     go_away(?PROTOCOL_ERROR, State).
 
--spec handshake(timeout|{frame, frame()}, connection()) ->
+-spec handshake(timeout|{frame, http2_frame:frame()}, connection()) ->
                     {next_state,
                      handshake|connected|closing,
                      connection()}.
@@ -335,7 +335,9 @@ closing(Message, Conn) ->
 %% route_frame's job needs to be "now that we've read a frame off the
 %% wire, do connection based things to it and/or forward it to the
 %% http2 stream processor (http2_stream:recv_frame)
--spec route_frame(frame() | {error, term()}, connection()) ->
+-spec route_frame(
+        http2_frame:frame() | {error, term()},
+        connection()) ->
     {next_state,
      connected | continuation | closing ,
      connection()}.
@@ -398,24 +400,6 @@ route_frame({#frame_header{
     lager:error("[~p] ~p frame only allowed on stream 0",
                 [Conn#connection.type, ?FT(Type)]),
     go_away(?PROTOCOL_ERROR, Conn);
-
-route_frame({#frame_header{
-                type=?WINDOW_UPDATE,
-                stream_id=StreamId
-               },
-             #window_update{
-                window_size_increment=WSI
-                }},
-            #connection{} = Conn)
-  when WSI < 1 ->
-    case StreamId of
-        0 ->
-            go_away(?PROTOCOL_ERROR, Conn);
-        _ ->
-            Stream = get_stream(StreamId, Conn#connection.streams),
-            http2_stream:rst_stream(Stream#stream.pid, ?PROTOCOL_ERROR)
-    end;
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Connection Level Frames
@@ -586,11 +570,11 @@ route_frame({#frame_header{type=?HEADERS}=FH, _Payload},
   when Conn#connection.type == server,
        FH#frame_header.stream_id rem 2 == 0 ->
     go_away(?PROTOCOL_ERROR, Conn);
-route_frame({#frame_header{stream_id=StreamId, type=?HEADERS}=FH, #headers{priority=P}},
-            #connection{}=Conn)
-  when ?IS_FLAG(FH#frame_header.flags, ?FLAG_PRIORITY),
-       P#priority.stream_id == FH#frame_header.stream_id ->
-    rst_stream(StreamId, ?PROTOCOL_ERROR, Conn);
+%route_frame({#frame_header{stream_id=StreamId, type=?HEADERS}=FH, #headers{priority=P}},
+%            #connection{}=Conn)
+%  when ?IS_FLAG(FH#frame_header.flags, ?FLAG_PRIORITY),
+%       P#priority.stream_id == FH#frame_header.stream_id ->
+%    rst_stream(StreamId, ?PROTOCOL_ERROR, Conn);
 route_frame({#frame_header{type=?HEADERS}=FH, _Payload}=Frame,
             #connection{}=Conn) ->
     StreamId = FH#frame_header.stream_id,
@@ -643,6 +627,7 @@ route_frame({#frame_header{type=?HEADERS}=FH, _Payload}=Frame,
           },
 
     maybe_hpack(ContinuationState, NewConn);
+
 route_frame(F={H=#frame_header{
                     stream_id=StreamId,
                     type=?CONTINUATION
@@ -667,10 +652,10 @@ route_frame({H, _Payload},
     when H#frame_header.type == ?PRIORITY,
          H#frame_header.stream_id == 0 ->
     go_away(?PROTOCOL_ERROR, Conn);
-route_frame({#frame_header{type=?PRIORITY, stream_id=StreamId}, #priority{}=P},
-            #connection{}=Conn)
-  when StreamId == P#priority.stream_id ->
-    rst_stream(StreamId, ?PROTOCOL_ERROR, Conn);
+%route_frame({#frame_header{type=?PRIORITY, stream_id=StreamId}, P},
+%            #connection{}=Conn)
+%  when StreamId == P#priority.stream_id ->
+%    rst_stream(StreamId, ?PROTOCOL_ERROR, Conn);
 route_frame({H, _Payload},
             #connection{} = Conn)
     when H#frame_header.type == ?PRIORITY ->
@@ -683,10 +668,9 @@ route_frame(
       stream_id=StreamId,
       type=?RST_STREAM
       },
-   #rst_stream{
-      error_code=EC
-      }},
+   Payload},
   #connection{} = Conn) ->
+    EC = http2_frame_rst_stream:error_code(Payload),
     lager:debug("[~p] Received RST_STREAM (~p) for Stream ~p",
                 [Conn#connection.type, EC, StreamId]),
     Streams = Conn#connection.streams,
@@ -700,12 +684,10 @@ route_frame(
 route_frame({H=#frame_header{
                   stream_id=StreamId
                  },
-             #push_promise{
-                promised_stream_id=PSID
-                }}=Frame,
+             Payload}=Frame,
             #connection{}=Conn)
     when H#frame_header.type == ?PUSH_PROMISE ->
-
+    PSID = http2_frame_push_promise:promised_stream_id(Payload),
     lager:debug("[~p] Received PUSH_PROMISE Frame on Stream ~p for Stream ~p",
                 [Conn#connection.type, StreamId, PSID]),
 
@@ -725,14 +707,11 @@ route_frame({H=#frame_header{
                       end_headers=?IS_FLAG(H#frame_header.flags, ?FLAG_END_HEADERS),
                       promised_id=PSID
                      },
-
     maybe_hpack(Continuation,
                 Conn#connection{
                   streams = [New|Streams]
                  });
-
 %% PING
-
 %% If not stream 0, then connection error
 route_frame({H, _Payload},
             #connection{} = Conn)
@@ -768,16 +747,18 @@ route_frame({H=#frame_header{stream_id=0}, _Payload},
     lager:debug("[~p] Received GOAWAY Frame for Stream 0",
                [Conn#connection.type]),
     go_away(?NO_ERROR, Conn);
+
+%% Window Update
 route_frame(
   {#frame_header{
       stream_id=0,
       type=?WINDOW_UPDATE
      },
-   #window_update{window_size_increment=WSI}},
+   Payload},
   #connection{
      send_window_size=SWS
     }=Conn) ->
-
+    WSI = http2_frame_window_update:size_increment(Payload),
     lager:debug("[~p] Stream 0 Window Update: ~p",
                 [Conn#connection.type, WSI]),
     NewSendWindow = SWS+WSI,
@@ -805,12 +786,12 @@ route_frame(
     end;
 route_frame(
   {#frame_header{type=?WINDOW_UPDATE}=FH,
-   #window_update{window_size_increment=WSI}},
+   Payload},
   #connection{}=Conn
  ) ->
     StreamId = FH#frame_header.stream_id,
     Streams = Conn#connection.streams,
-
+    WSI = http2_frame_window_update:size_increment(Payload),
     lager:debug("[~p] Received WINDOW_UPDATE Frame for Stream ~p",
                 [Conn#connection.type, StreamId]),
 
@@ -933,9 +914,7 @@ s_send_what_we_can(SWS, MFS, Stream) ->
                      type=?DATA,
                      length=QueueSize
                     },
-                  #data{
-                     data=Stream#stream.queued_data %% Full Body
-                    }},
+                  http2_frame_data:new(Stream#stream.queued_data)}, %% Full Body
                  QueueSize,
                  Stream#stream{
                    queued_data=done,
@@ -947,9 +926,7 @@ s_send_what_we_can(SWS, MFS, Stream) ->
                      type=?DATA,
                      length=MaxToSend
                     },
-                  #data{
-                     data=BinToSend
-                    }},
+                  http2_frame_data:new(BinToSend)},
                  MaxToSend,
                  Stream#stream{
                    queued_data=Rest,
@@ -1244,10 +1221,7 @@ go_away(ErrorCode,
         #connection{
            next_available_stream_id=NAS
           }=Conn) ->
-    GoAway = #goaway{
-                last_stream_id=NAS, %% maybe not the best idea.
-                error_code=ErrorCode
-               },
+    GoAway = http2_frame_goaway:new(NAS, ErrorCode),
     GoAwayBin = http2_frame:to_binary({#frame_header{
                                           stream_id=0
                                          }, GoAway}),
@@ -1264,7 +1238,7 @@ go_away(ErrorCode,
 rst_stream(StreamId, ErrorCode, Conn) ->
     case get_stream(StreamId, Conn#connection.streams) of
         false ->
-            RstStream = #rst_stream{error_code=ErrorCode},
+            RstStream = http2_frame_rst_stream:new(ErrorCode),
             RstStreamBin = http2_frame:to_binary(
                              {#frame_header{
                                  stream_id=StreamId
@@ -1426,18 +1400,24 @@ handle_socket_data(Data,
             gen_fsm:send_event(self(), {frame, Frame}),
             handle_socket_data(Rem, StateName, NewConn);
         %% Not enough bytes left to make a header :(
-        {error, not_enough_header, Bin} ->
+        {not_enough_header, Bin} ->
             %% This is a situation where more bytes should come soon,
             %% so let's switch back to active, once
             active_once(Socket),
             {next_state, StateName, NewConn#connection{buffer={binary, Bin}}};
         %% Not enough bytes to make a payload
-        {error, not_enough_payload, Header, Bin} ->
+        {not_enough_payload, Header, Bin} ->
             %% This too
             active_once(Socket),
             {next_state, StateName, NewConn#connection{buffer={frame, Header, Bin}}};
-        {error, Code} ->
-            go_away(Code, Conn)
+%%        {error, Code} ->
+%%            go_away(Code, NewConn);
+        {error, 0, Code, _Rem} ->
+            %% Remaining Bytes don't matter, we're closing up shop.
+            go_away(Code, NewConn);
+        {error, StreamId, Code, Rem} ->
+            rst_stream(StreamId, Code, NewConn),
+            handle_socket_data(Rem, StateName, NewConn)
     end.
 
 handle_socket_passive(StateName, Conn) ->

--- a/src/http2_connection.erl
+++ b/src/http2_connection.erl
@@ -570,11 +570,6 @@ route_frame({#frame_header{type=?HEADERS}=FH, _Payload},
   when Conn#connection.type == server,
        FH#frame_header.stream_id rem 2 == 0 ->
     go_away(?PROTOCOL_ERROR, Conn);
-%route_frame({#frame_header{stream_id=StreamId, type=?HEADERS}=FH, #headers{priority=P}},
-%            #connection{}=Conn)
-%  when ?IS_FLAG(FH#frame_header.flags, ?FLAG_PRIORITY),
-%       P#priority.stream_id == FH#frame_header.stream_id ->
-%    rst_stream(StreamId, ?PROTOCOL_ERROR, Conn);
 route_frame({#frame_header{type=?HEADERS}=FH, _Payload}=Frame,
             #connection{}=Conn) ->
     StreamId = FH#frame_header.stream_id,
@@ -652,10 +647,6 @@ route_frame({H, _Payload},
     when H#frame_header.type == ?PRIORITY,
          H#frame_header.stream_id == 0 ->
     go_away(?PROTOCOL_ERROR, Conn);
-%route_frame({#frame_header{type=?PRIORITY, stream_id=StreamId}, P},
-%            #connection{}=Conn)
-%  when StreamId == P#priority.stream_id ->
-%    rst_stream(StreamId, ?PROTOCOL_ERROR, Conn);
 route_frame({H, _Payload},
             #connection{} = Conn)
     when H#frame_header.type == ?PRIORITY ->
@@ -1410,8 +1401,6 @@ handle_socket_data(Data,
             %% This too
             active_once(Socket),
             {next_state, StateName, NewConn#connection{buffer={frame, Header, Bin}}};
-%%        {error, Code} ->
-%%            go_away(Code, NewConn);
         {error, 0, Code, _Rem} ->
             %% Remaining Bytes don't matter, we're closing up shop.
             go_away(Code, NewConn);

--- a/src/http2_frame_continuation.erl
+++ b/src/http2_frame_continuation.erl
@@ -31,6 +31,11 @@ new(Bin) ->
 -spec read_binary(binary(), frame_header()) ->
                          {ok, payload(), binary()}
                        | {error, stream_id(), error_code(), binary()}.
+read_binary(_,
+            #frame_header{
+               stream_id=0
+               }) ->
+    {error, 0, ?PROTOCOL_ERROR, <<>>};
 read_binary(Bin, #frame_header{length=Length}) ->
     <<Data:Length/binary,Rem/bits>> = Bin,
     Payload = #continuation{

--- a/src/http2_frame_continuation.erl
+++ b/src/http2_frame_continuation.erl
@@ -4,14 +4,33 @@
 
 -behaviour(http2_frame).
 
--export([
+-export(
+   [
+    block_fragment/1,
     format/1,
+    new/1,
     read_binary/2,
     to_binary/1
-    ]).
+   ]).
 
+-record(continuation, {
+          block_fragment :: binary()
+}).
+-type payload() :: #continuation{}.
+-export_type([payload/0]).
+
+-spec block_fragment(payload()) -> binary().
+block_fragment(#continuation{block_fragment=BF}) ->
+    BF.
+
+-spec new(binary()) -> payload().
+new(Bin) ->
+    #continuation{
+       block_fragment=Bin
+      }.
 -spec read_binary(binary(), frame_header()) ->
-    {ok, payload(), binary()} | {error, term()}.
+                         {ok, payload(), binary()}
+                       | {error, stream_id(), error_code(), binary()}.
 read_binary(Bin, #frame_header{length=Length}) ->
     <<Data:Length/binary,Rem/bits>> = Bin,
     Payload = #continuation{
@@ -19,10 +38,10 @@ read_binary(Bin, #frame_header{length=Length}) ->
                 },
     {ok, Payload, Rem}.
 
--spec format(continuation()) -> iodata().
+-spec format(payload()) -> iodata().
 format(Payload) ->
     io_lib:format("[Continuation: ~p ]", [Payload]).
 
--spec to_binary(continuation()) -> iodata().
+-spec to_binary(payload()) -> iodata().
 to_binary(#continuation{block_fragment=BF}) ->
     BF.

--- a/src/http2_frame_data.erl
+++ b/src/http2_frame_data.erl
@@ -6,12 +6,25 @@
          format/1,
          read_binary/2,
          to_frames/3,
-         to_binary/1
+         to_binary/1,
+         data/1,
+         new/1
         ]).
 
 -behaviour(http2_frame).
 
--spec format(data()) -> iodata().
+-record(data, {
+    data :: iodata()
+  }).
+-type payload() :: #data{}.
+-type frame() :: {#frame_header{}, payload()}.
+-export_type([frame/0, payload/0]).
+
+-spec data(payload()) -> iodata().
+data(#data{data=D}) ->
+    D.
+
+-spec format(payload()) -> iodata().
 format(Payload) ->
     BinToShow = case size(Payload) > 7 of
         false ->
@@ -21,6 +34,10 @@ format(Payload) ->
             Start
     end,
     io_lib:format("[Data: {data: ~p ...}]", [BinToShow]).
+
+-spec new(binary()) -> payload().
+new(Data) ->
+    #data{data=Data}.
 
 -spec read_binary(binary(), frame_header()) ->
     {ok, payload(), binary()}.
@@ -61,6 +78,6 @@ to_frames(StreamId, Data, S=#settings{max_frame_size=MFS}) ->
     end.
 
 
--spec to_binary(data()) -> iodata().
+-spec to_binary(payload()) -> iodata().
 to_binary(#data{data=D}) ->
     D.

--- a/src/http2_frame_data.erl
+++ b/src/http2_frame_data.erl
@@ -39,7 +39,10 @@ new(Data) ->
     #data{data=Data}.
 
 -spec read_binary(binary(), frame_header()) ->
-    {ok, payload(), binary()}.
+                         {ok, payload(), binary()}
+                       | {error, stream_id(), error_code(), binary()}.
+read_binary(_, #frame_header{stream_id=0}) ->
+    {error, 0, ?PROTOCOL_ERROR, <<>>};
 read_binary(Bin, _H=#frame_header{length=0}) ->
     {ok, #data{data= <<>>}, Bin};
 read_binary(Bin, H=#frame_header{length=L}) ->

--- a/src/http2_frame_data.erl
+++ b/src/http2_frame_data.erl
@@ -17,8 +17,7 @@
     data :: iodata()
   }).
 -type payload() :: #data{}.
--type frame() :: {#frame_header{}, payload()}.
--export_type([frame/0, payload/0]).
+-export_type([payload/0]).
 
 -spec data(payload()) -> iodata().
 data(#data{data=D}) ->
@@ -53,7 +52,7 @@ read_binary(Bin, H=#frame_header{length=L}) ->
             {ok, #data{data=Data}, Rem}
     end.
 
--spec to_frames(stream_id(), iodata(), settings()) -> [frame()].
+-spec to_frames(stream_id(), iodata(), settings()) -> [http2_frame:frame()].
 to_frames(StreamId, IOList, Settings)
   when is_list(IOList) ->
     to_frames(StreamId, iolist_to_binary(IOList), Settings);

--- a/src/http2_frame_goaway.erl
+++ b/src/http2_frame_goaway.erl
@@ -4,18 +4,42 @@
 
 -behaviour(http2_frame).
 
--export([
+-export(
+   [
+    error_code/1,
     format/1,
+    new/2,
     read_binary/2,
     to_binary/1
-    ]).
+   ]).
 
--spec format(goaway()) -> iodata().
+-record(goaway, {
+          last_stream_id :: stream_id(),
+          error_code :: error_code(),
+          additional_debug_data = <<>> :: binary()
+}).
+-type payload() :: #goaway{}.
+-export_type([payload/0]).
+
+-spec error_code(payload()) -> error_code().
+error_code(#goaway{error_code=EC}) ->
+    EC.
+
+-spec format(payload()) -> iodata().
 format(Payload) ->
     io_lib:format("[GOAWAY: ~p]", [Payload]).
 
+
+-spec new(stream_id(), error_code()) -> payload().
+new(StreamId, ErrorCode) ->
+    #goaway{
+       last_stream_id = StreamId,
+       error_code = ErrorCode
+      }.
+
 -spec read_binary(binary(), frame_header()) ->
-    {ok, payload(), binary()} | {error, term()}.
+                         {ok, payload(), binary()}
+                       | {error, stream_id(), error_code(), binary()}.
 read_binary(Bin, #frame_header{length=L}) ->
     <<Data:L/binary,Rem/bits>> = Bin,
     <<_R:1,LastStream:31,ErrorCode:32,Extra/bits>> = Data,
@@ -26,7 +50,7 @@ read_binary(Bin, #frame_header{length=L}) ->
                 },
     {ok, Payload, Rem}.
 
--spec to_binary(goaway()) -> iodata().
+-spec to_binary(payload()) -> iodata().
 to_binary(#goaway{
              last_stream_id=LSID,
              error_code=EC,

--- a/src/http2_frame_goaway.erl
+++ b/src/http2_frame_goaway.erl
@@ -40,7 +40,11 @@ new(StreamId, ErrorCode) ->
 -spec read_binary(binary(), frame_header()) ->
                          {ok, payload(), binary()}
                        | {error, stream_id(), error_code(), binary()}.
-read_binary(Bin, #frame_header{length=L}) ->
+read_binary(Bin,
+            #frame_header{
+               length=L,
+               stream_id=0
+              }) ->
     <<Data:L/binary,Rem/bits>> = Bin,
     <<_R:1,LastStream:31,ErrorCode:32,Extra/bits>> = Data,
     Payload = #goaway{
@@ -48,7 +52,9 @@ read_binary(Bin, #frame_header{length=L}) ->
                  error_code = ErrorCode,
                  additional_debug_data = Extra
                 },
-    {ok, Payload, Rem}.
+    {ok, Payload, Rem};
+read_binary(_, _) ->
+    {error, 0, ?PROTOCOL_ERROR, <<>>}.
 
 -spec to_binary(payload()) -> iodata().
 to_binary(#goaway{

--- a/src/http2_frame_headers.erl
+++ b/src/http2_frame_headers.erl
@@ -44,6 +44,11 @@ new(Priority, BlockFragment) ->
                   frame_header()) ->
                          {ok, payload(), binary()}
                        | {error, stream_id(), error_code(), binary()}.
+read_binary(_,
+            #frame_header{
+               stream_id=0
+              }) ->
+    {error, 0, ?PROTOCOL_ERROR, <<>>};
 read_binary(Bin, H = #frame_header{length=L}) ->
     <<PayloadBin:L/binary,Rem/bits>> = Bin,
     case http2_padding:read_possibly_padded_payload(PayloadBin, H) of

--- a/src/http2_frame_headers.erl
+++ b/src/http2_frame_headers.erl
@@ -4,40 +4,73 @@
 
 -behaviour(http2_frame).
 
--export([
+-export(
+   [
     format/1,
     from_frames/1,
+    new/1,
+    new/2,
     read_binary/2,
     to_frames/5,
     to_binary/1
   ]).
 
--spec format(headers()) -> iodata().
+-record(headers,
+        {
+          priority = undefined :: http2_frame_priority:payload() | undefined,
+          block_fragment :: binary()
+        }).
+-type payload() :: #headers{}.
+-export_type([payload/0]).
+
+-spec format(payload()) -> iodata().
 format(Payload) ->
     io_lib:format("[Headers: ~p]", [Payload]).
 
--spec read_binary(binary(), frame_header()) ->
+-spec new(binary()) -> payload().
+new(BlockFragment) ->
+    #headers{block_fragment=BlockFragment}.
+
+-spec new(http2_frame_priority:payload(),
+          binary()) ->
+                 payload().
+new(Priority, BlockFragment) ->
+    #headers{
+       priority=Priority,
+       block_fragment=BlockFragment
+      }.
+
+-spec read_binary(binary(),
+                  frame_header()) ->
                          {ok, payload(), binary()}
-                       | {error, error_code()}.
+                       | {error, stream_id(), error_code(), binary()}.
 read_binary(Bin, H = #frame_header{length=L}) ->
     <<PayloadBin:L/binary,Rem/bits>> = Bin,
     case http2_padding:read_possibly_padded_payload(PayloadBin, H) of
         {error, Code} ->
-            {error, Code};
+            {error, 0, Code, Rem};
         Data ->
-            {Priority, HeaderFragment} =
+            {Priority, PSID, HeaderFragment} =
                 case is_priority(H) of
                     true ->
-                        http2_frame_priority:read_priority(Data);
+                        {P, PRem} = http2_frame_priority:read_priority(Data),
+                        PStream = http2_frame_priority:stream_id(P),
+                        {P, PStream, PRem};
                     false ->
-                        {undefined, Data}
+                        {undefined, undefined, Data}
                 end,
 
-            Payload = #headers{
-                         priority=Priority,
-                         block_fragment=HeaderFragment
-                        },
-            {ok, Payload, Rem}
+            case PSID =:= H#frame_header.stream_id of
+                true ->
+                    {error, PSID, ?PROTOCOL_ERROR, Rem};
+                false ->
+
+                    Payload = #headers{
+                                 priority=Priority,
+                                 block_fragment=HeaderFragment
+                                },
+                    {ok, Payload, Rem}
+            end
     end.
 
 is_priority(#frame_header{flags=F}) when ?IS_FLAG(F, ?FLAG_PRIORITY) ->
@@ -50,7 +83,7 @@ is_priority(_) ->
                 EncodeContext :: hpack:context(),
                 MaxFrameSize  :: pos_integer(),
                 EndStream     :: boolean()) ->
-                       {[frame()], hpack:context()}.
+                       {[http2_frame:frame()], hpack:context()}.
 to_frames(StreamId, Headers, EncodeContext, MaxFrameSize, EndStream) ->
     {ok, {HeadersBin, NewContext}} = hpack:encode(Headers, EncodeContext),
 
@@ -61,7 +94,7 @@ to_frames(StreamId, Headers, EncodeContext, MaxFrameSize, EndStream) ->
 
     {Frames, NewContext}.
 
--spec to_binary(headers()) -> iodata().
+-spec to_binary(payload()) -> iodata().
 to_binary(#headers{
              priority=P,
              block_fragment=BF
@@ -73,15 +106,17 @@ to_binary(#headers{
             [http2_frame_priority:to_binary(P), BF]
     end.
 
--spec from_frames([frame()], binary()) -> binary().
+-spec from_frames([http2_frame:frame()], binary()) -> binary().
 from_frames([{#frame_header{type=?HEADERS},#headers{block_fragment=BF}}|Continuations])->
     from_frames(Continuations, BF);
-from_frames([{#frame_header{type=?PUSH_PROMISE},#push_promise{block_fragment=BF}}|Continuations])->
+from_frames([{#frame_header{type=?PUSH_PROMISE},PP}|Continuations])->
+    BF = http2_frame_push_promise:block_fragment(PP),
     from_frames(Continuations, BF).
 
 from_frames([], Acc) ->
     Acc;
-from_frames([{#frame_header{type=?CONTINUATION},#continuation{block_fragment=BF}}|Continuations], Acc) ->
+from_frames([{#frame_header{type=?CONTINUATION},Cont}|Continuations], Acc) ->
+    BF = http2_frame_continuation:block_fragment(Cont),
     from_frames(Continuations, <<Acc/binary,BF/binary>>).
 
 -spec split(Binary::binary(),
@@ -109,7 +144,7 @@ split(Binary, MaxFrameSize, Acc) ->
 -spec build_frames(StreamId :: stream_id(),
                    Chunks::[binary()],
                    EndStream::boolean()) ->
-                          [frame()].
+                          [http2_frame:frame()].
 build_frames(StreamId, [FirstChunk|Rest], EndStream) ->
     Flag = case EndStream of
                true ->
@@ -137,8 +172,8 @@ build_frames(StreamId, [FirstChunk|Rest], EndStream) ->
 
 -spec build_frames_(StreamId::stream_id(),
                     Chunks::[binary()],
-                    Acc::[frame()])->
-                           [frame()].
+                    Acc::[http2_frame:frame()])->
+                           [http2_frame:frame()].
 build_frames_(_StreamId, [], Acc) ->
     Acc;
 build_frames_(StreamId, [NextChunk|Rest], Acc) ->
@@ -149,8 +184,6 @@ build_frames_(StreamId, [NextChunk|Rest], Acc) ->
          flags=0,
          length=byte_size(NextChunk)
         },
-      #continuation{
-         block_fragment=NextChunk
-        }
+      http2_frame_continuation:new(NextChunk)
      },
     build_frames_(StreamId, Rest, [NextFrame|Acc]).

--- a/src/http2_frame_ping.erl
+++ b/src/http2_frame_ping.erl
@@ -30,7 +30,18 @@ new(Bin) ->
 -spec read_binary(binary(), frame_header()) ->
                          {ok, payload(), binary()}
                        | {error, stream_id(), error_code(), binary()}.
-read_binary(<<Data:8/binary,Rem/bits>>, #frame_header{length=8}) ->
+read_binary(_,
+            #frame_header{
+               length=L
+               })
+  when L =/= 8->
+     {error, 0, ?FRAME_SIZE_ERROR, <<>>};
+read_binary(<<Data:8/binary,Rem/bits>>,
+            #frame_header{
+               length=8,
+               stream_id=0
+              }
+           ) ->
     Payload = #ping{
                  opaque_data = Data
                 },

--- a/src/http2_frame_ping.erl
+++ b/src/http2_frame_ping.erl
@@ -34,7 +34,9 @@ read_binary(<<Data:8/binary,Rem/bits>>, #frame_header{length=8}) ->
     Payload = #ping{
                  opaque_data = Data
                 },
-    {ok, Payload, Rem}.
+    {ok, Payload, Rem};
+read_binary(_, _) ->
+    {error, 0, ?PROTOCOL_ERROR, <<>>}.
 
 -spec to_binary(payload()) -> iodata().
 to_binary(#ping{opaque_data=D}) ->

--- a/src/http2_frame_ping.erl
+++ b/src/http2_frame_ping.erl
@@ -4,30 +4,43 @@
 
 -behaviour(http2_frame).
 
--export([
+-export(
+   [
     format/1,
     read_binary/2,
     to_binary/1,
-    ack/1
+    ack/1,
+    new/1
     ]).
 
--spec format(ping()) -> iodata().
+-record(ping, {
+          opaque_data :: binary()
+}).
+-type payload() :: #ping{}.
+-export_type([payload/0]).
+
+-spec format(payload()) -> iodata().
 format(Payload) ->
     io_lib:format("[Ping: ~p]", [Payload]).
 
+-spec new(binary()) -> payload().
+new(Bin) ->
+    #ping{opaque_data=Bin}.
+
 -spec read_binary(binary(), frame_header()) ->
-    {ok, payload(), binary()} | {error, term()}.
+                         {ok, payload(), binary()}
+                       | {error, stream_id(), error_code(), binary()}.
 read_binary(<<Data:8/binary,Rem/bits>>, #frame_header{length=8}) ->
     Payload = #ping{
                  opaque_data = Data
                 },
     {ok, Payload, Rem}.
 
--spec to_binary(ping()) -> iodata().
+-spec to_binary(payload()) -> iodata().
 to_binary(#ping{opaque_data=D}) ->
     D.
 
--spec ack(ping()) -> {frame_header(), ping()}.
+-spec ack(payload()) -> {frame_header(), payload()}.
 ack(Ping) ->
     {#frame_header{
         length = 8,

--- a/src/http2_frame_priority.erl
+++ b/src/http2_frame_priority.erl
@@ -37,7 +37,21 @@ new(Exclusive, StreamId, Weight) ->
 -spec read_binary(binary(), frame_header()) ->
                          {ok, payload(), binary()}
                        | {error, stream_id(), error_code(), binary()}.
-read_binary(Bin, #frame_header{}=H) ->
+read_binary(_,
+            #frame_header{
+               stream_id=0
+              }) ->
+    {error, 0, ?PROTOCOL_ERROR, <<>>};
+read_binary(_,
+           #frame_header{
+             length=L
+             })
+  when L =/= 5 ->
+    {error, 0, ?FRAME_SIZE_ERROR, <<>>};
+read_binary(Bin,
+            #frame_header{
+               length=5
+              }=H) ->
     {Payload, Rem} = read_priority(Bin),
     PriorityStream = Payload#priority.stream_id,
     case H#frame_header.stream_id of

--- a/src/http2_frame_priority.erl
+++ b/src/http2_frame_priority.erl
@@ -2,27 +2,54 @@
 
 -include("http2.hrl").
 
--export([
-         format/1,
-         read_binary/2,
-         read_priority/1,
-         to_binary/1
-        ]).
+-export(
+   [
+    format/1,
+    new/3,
+    stream_id/1,
+    read_binary/2,
+    read_priority/1,
+    to_binary/1
+   ]).
+
+-record(priority, {
+    exclusive = 0 :: 0 | 1,
+    stream_id = 0 :: stream_id(),
+    weight = 0 :: non_neg_integer()
+  }).
+-type payload() :: #priority{}.
+-export_type([payload/0]).
 
 -behaviour(http2_frame).
 
--spec format(priority()) -> iodata().
+-spec format(payload()) -> iodata().
 format(Payload) ->
     io_lib:format("[Priority: ~p]", [Payload]).
 
--spec read_binary(binary(), frame_header()) ->
-    {ok, payload(), binary()} |
-    {error, term()}.
-read_binary(Bin, #frame_header{stream_id=_Sid}) ->
-    {Payload, Rem} = read_priority(Bin),
-    {ok, Payload, Rem}.
+-spec new(0|1, stream_id(), non_neg_integer()) -> payload().
+new(Exclusive, StreamId, Weight) ->
+    #priority{
+       exclusive=Exclusive,
+       stream_id=StreamId,
+       weight=Weight
+      }.
 
--spec read_priority(binary()) -> {priority(), binary()}.
+-spec read_binary(binary(), frame_header()) ->
+                         {ok, payload(), binary()}
+                       | {error, stream_id(), error_code(), binary()}.
+read_binary(Bin, #frame_header{}=H) ->
+    {Payload, Rem} = read_priority(Bin),
+    PriorityStream = Payload#priority.stream_id,
+    case H#frame_header.stream_id of
+        0 ->
+            {error, 0, ?PROTOCOL_ERROR, Rem};
+        PriorityStream ->
+            {error, H#frame_header.stream_id, ?PROTOCOL_ERROR, Rem};
+        _ ->
+            {ok, Payload, Rem}
+    end.
+
+-spec read_priority(binary()) -> {payload(), binary()}.
 read_priority(Binary) ->
     <<Exclusive:1,StreamId:31,Weight:8,Rem/bits>> = Binary,
     Payload = #priority{
@@ -32,7 +59,11 @@ read_priority(Binary) ->
     },
     {Payload, Rem}.
 
--spec to_binary(priority()) -> iodata().
+-spec stream_id(payload()) -> stream_id().
+stream_id(#priority{stream_id=S}) ->
+    S.
+
+-spec to_binary(payload()) -> iodata().
 to_binary(#priority{
              exclusive=E,
              stream_id=StreamId,

--- a/src/http2_frame_push_promise.erl
+++ b/src/http2_frame_push_promise.erl
@@ -44,6 +44,11 @@ new(StreamId, Bin) ->
 -spec read_binary(binary(), frame_header()) ->
                          {ok, payload(), binary()}
                        | {error, stream_id(), error_code(), binary()}.
+read_binary(_,
+            #frame_header{
+               stream_id=0
+               }) ->
+    {error, 0, ?PROTOCOL_ERROR, <<>>};
 read_binary(Bin, H=#frame_header{length=L}) ->
     <<PayloadBin:L/binary,Rem/binary>> = Bin,
     Data = http2_padding:read_possibly_padded_payload(PayloadBin, H),

--- a/src/http2_frame_push_promise.erl
+++ b/src/http2_frame_push_promise.erl
@@ -4,19 +4,46 @@
 
 -behaviour(http2_frame).
 
--export([
+-export(
+   [
+    block_fragment/1,
     format/1,
+    new/2,
+    promised_stream_id/1,
     read_binary/2,
     to_binary/1,
     to_frame/4
     ]).
 
--spec format(push_promise()) -> iodata().
+-record(push_promise, {
+          promised_stream_id :: stream_id(),
+          block_fragment :: binary()
+}).
+-type payload() :: #push_promise{}.
+-export_type([payload/0]).
+
+-spec block_fragment(payload()) -> binary().
+block_fragment(#push_promise{block_fragment=BF}) ->
+    BF.
+
+-spec promised_stream_id(payload()) -> stream_id().
+promised_stream_id(#push_promise{promised_stream_id=PSID}) ->
+    PSID.
+
+-spec format(payload()) -> iodata().
 format(Payload) ->
     io_lib:format("[Headers: ~p]", [Payload]).
 
+-spec new(stream_id(), binary()) -> payload().
+new(StreamId, Bin) ->
+    #push_promise{
+       promised_stream_id=StreamId,
+       block_fragment=Bin
+      }.
+
 -spec read_binary(binary(), frame_header()) ->
-    {ok, payload(), binary()} | {error, term()}.
+                         {ok, payload(), binary()}
+                       | {error, stream_id(), error_code(), binary()}.
 read_binary(Bin, H=#frame_header{length=L}) ->
     <<PayloadBin:L/binary,Rem/binary>> = Bin,
     Data = http2_padding:read_possibly_padded_payload(PayloadBin, H),
@@ -28,7 +55,7 @@ read_binary(Bin, H=#frame_header{length=L}) ->
     {ok, Payload, Rem}.
 
 -spec to_frame(pos_integer(), pos_integer(), hpack:headers(), hpack:context()) ->
-                      {{frame_header(), push_promise()}, hpack:context()}.
+                      {{frame_header(), payload()}, hpack:context()}.
 %% Maybe break this up into continuations like the data frame
 to_frame(StreamId, PStreamId, Headers, EncodeContext) ->
     {ok, {HeadersToSend, NewContext}} = hpack:encode(Headers, EncodeContext),
@@ -45,7 +72,7 @@ to_frame(StreamId, PStreamId, Headers, EncodeContext) ->
         }},
     NewContext}.
 
--spec to_binary(push_promise()) -> iodata().
+-spec to_binary(payload()) -> iodata().
 to_binary(#push_promise{
              promised_stream_id=PSID,
              block_fragment=BF

--- a/src/http2_frame_rst_stream.erl
+++ b/src/http2_frame_rst_stream.erl
@@ -1,16 +1,32 @@
 -module(http2_frame_rst_stream).
-
--export([
-    format/1,
-    read_binary/2,
-    to_binary/1
-    ]).
-
 -include("http2.hrl").
+-export([
+         new/1,
+         error_code/1,
+         format/1,
+         read_binary/2,
+         to_binary/1
+        ]).
+
+-record(rst_stream, {
+          error_code :: error_code()
+}).
+-type payload() :: #rst_stream{}.
+-export_type([payload/0]).
 
 -behaviour(http2_frame).
 
--spec format(rst_stream()) -> iodata().
+-spec new(error_code()) -> payload().
+new(ErrorCode) ->
+    #rst_stream{
+       error_code=ErrorCode
+      }.
+
+-spec error_code(payload()) -> error_code().
+error_code(#rst_stream{error_code=EC}) ->
+    EC.
+
+-spec format(payload()) -> iodata().
 format(Payload) ->
     io_lib:format("[RST Stream: ~p]", [Payload]).
 
@@ -24,6 +40,6 @@ read_binary(<<ErrorCode:32,Rem/bits>>, #frame_header{length=4}) ->
 read_binary(_, #frame_header{stream_id=0}) ->
     {error, frame_size_error}.
 
--spec to_binary(rst_stream()) -> iodata().
+-spec to_binary(payload()) -> iodata().
 to_binary(#rst_stream{error_code=C}) ->
     <<C:32>>.

--- a/src/http2_frame_settings.erl
+++ b/src/http2_frame_settings.erl
@@ -65,12 +65,23 @@ format({settings, PList}) ->
 -spec read_binary(binary(), frame_header()) ->
                          {ok, payload(), binary()}
                        | {error, stream_id(), error_code(), binary()}.
-read_binary(Bin, _Header = #frame_header{length=0}) ->
+read_binary(Bin,
+            #frame_header{
+               length=0,
+               stream_id=0
+              }) ->
     {ok, {settings, []}, Bin};
-read_binary(Bin, _Header = #frame_header{length=Length}) ->
+read_binary(Bin,
+            #frame_header{
+               length=Length,
+               stream_id=0
+              }) ->
     <<SettingsBin:Length/binary,Rem/bits>> = Bin,
     Settings = parse_settings(SettingsBin),
-    {ok, {settings, Settings}, Rem}.
+    {ok, {settings, Settings}, Rem};
+read_binary(_, _) ->
+    {error, 0, ?PROTOCOL_ERROR, <<>>}.
+
 
 -spec parse_settings(binary()) -> [proplists:property()].
 parse_settings(Bin) ->

--- a/src/http2_frame_settings.erl
+++ b/src/http2_frame_settings.erl
@@ -4,19 +4,30 @@
 
 -behaviour(http2_frame).
 
--export([
-         format/1,
-         read_binary/2,
-         send/1,
-         send/2,
-         ack/0,
-         ack/1,
-         to_binary/1,
-         overlay/2,
-         validate/1
-        ]).
+-export(
+   [
+    format/1,
+    read_binary/2,
+    send/1,
+    send/2,
+    ack/0,
+    ack/1,
+    to_binary/1,
+    overlay/2,
+    validate/1
+   ]).
 
--spec format(settings()|binary()|{settings, [proplists:property()]}) -> iodata().
+%%TODO
+-type payload() :: #settings{} | {settings, proplist()}.
+
+-type name() :: binary().
+-type property() :: {name(), any()}.
+-type proplist() :: [property()].
+
+-export_type([payload/0, name/0, property/0, proplist/0]).
+
+
+-spec format(payload()|binary()|{settings, [proplists:property()]}) -> iodata().
 format(<<>>) -> "Ack!";
 format(#settings{
         header_table_size        = HTS,
@@ -52,8 +63,8 @@ format({settings, PList}) ->
     io_lib:format("~p", [L]).
 
 -spec read_binary(binary(), frame_header()) ->
-    {ok, payload(), binary()} |
-    {error, term()}.
+                         {ok, payload(), binary()}
+                       | {error, stream_id(), error_code(), binary()}.
 read_binary(Bin, _Header = #frame_header{length=0}) ->
     {ok, {settings, []}, Bin};
 read_binary(Bin, _Header = #frame_header{length=Length}) ->
@@ -81,7 +92,7 @@ parse_settings(<<0,6,Val:4/binary,T/binary>>, S)->
 parse_settings(<<>>, Settings) ->
     Settings.
 
--spec overlay(settings(), {settings, [proplists:property()]}) -> settings().
+-spec overlay(payload(), {settings, [proplists:property()]}) -> payload().
 overlay(S, {settings, [{?SETTINGS_HEADER_TABLE_SIZE, Val}|PList]}) ->
     overlay(S#settings{header_table_size=Val}, {settings, PList});
 overlay(S, {settings, [{?SETTINGS_ENABLE_PUSH, Val}|PList]}) ->
@@ -97,7 +108,7 @@ overlay(S, {settings, [{?SETTINGS_MAX_HEADER_LIST_SIZE, Val}|PList]}) ->
 overlay(S, {settings, []}) ->
     S.
 
--spec send(settings()) -> binary().
+-spec send(payload()) -> binary().
 send(Settings) ->
     List = http2_settings:to_proplist(Settings),
     Payload = make_payload(List),
@@ -105,7 +116,7 @@ send(Settings) ->
     Header = <<L:24,?SETTINGS:8,16#0:8,0:1,0:31>>,
     <<Header/binary, Payload/binary>>.
 
--spec send(settings(), settings()) -> binary().
+-spec send(payload(), payload()) -> binary().
 send(PrevSettings, NewSettings) ->
     Diff = http2_settings:diff(PrevSettings, NewSettings),
     Payload = make_payload(Diff),
@@ -113,7 +124,7 @@ send(PrevSettings, NewSettings) ->
     Header = <<L:24,?SETTINGS:8,16#0:8,0:1,0:31>>,
     <<Header/binary, Payload/binary>>.
 
--spec make_payload(settings_proplist()) -> binary().
+-spec make_payload(proplist()) -> binary().
 make_payload(Diff) ->
     make_payload_(lists:reverse(Diff), <<>>).
 
@@ -132,11 +143,11 @@ ack() ->
 ack({Transport,Socket}) ->
     Transport:send(Socket, <<0:24,4:8,1:8,0:1,0:31>>).
 
--spec to_binary(settings()) -> iodata().
+-spec to_binary(payload()) -> iodata().
 to_binary(#settings{}=Settings) ->
     [to_binary(S, Settings) || S <- ?SETTING_NAMES].
 
--spec to_binary(binary(), settings()) -> binary().
+-spec to_binary(binary(), payload()) -> binary().
 to_binary(?SETTINGS_HEADER_TABLE_SIZE, #settings{header_table_size=undefined}) ->
     <<>>;
 to_binary(?SETTINGS_HEADER_TABLE_SIZE, #settings{header_table_size=HTS}) ->

--- a/src/http2_frame_window_update.erl
+++ b/src/http2_frame_window_update.erl
@@ -4,28 +4,47 @@
 
 -behaviour(http2_frame).
 
--export([
-         format/1,
-         read_binary/2,
-         send/3,
-         to_binary/1
-]).
+-export(
+   [
+    new/1,
+    format/1,
+    read_binary/2,
+    send/3,
+    size_increment/1,
+    to_binary/1
+   ]).
 
--spec format(window_update()) -> iodata().
+-record(window_update, {
+          window_size_increment :: non_neg_integer()
+         }).
+-type payload() :: #window_update{}.
+-export_type([payload/0]).
+
+-spec format(payload()) -> iodata().
 format(Payload) ->
     io_lib:format("[Window Update: ~p]", [Payload]).
 
+-spec new(non_neg_integer()) -> payload().
+new(Increment) ->
+    #window_update{window_size_increment=Increment}.
+
+
 -spec read_binary(Bin::binary(),
                       Header::frame_header()) ->
-    {ok, payload(), binary()} | {error, term()}.
+                         {ok, payload(), binary()}
+                       | {error, stream_id(), error_code(), binary()}.
+read_binary(<<_R:1,0:31,Rem/bits>>, FH) ->
+    {error, FH#frame_header.stream_id, ?PROTOCOL_ERROR, Rem};
 read_binary(Bin, #frame_header{length=4}) ->
     <<_R:1,Increment:31,Rem/bits>> = Bin,
     Payload = #window_update{
                  window_size_increment=Increment
                 },
     {ok, Payload, Rem};
-read_binary(_, _) ->
-    {error, frame_size_error}.
+read_binary(_, #frame_header{}=H) ->
+    %TODO: Maybe return some Rem in element(4) once we know what that
+    %is
+    {error, H#frame_header.stream_id, ?FRAME_SIZE_ERROR, <<>>}.
 
 -spec send(sock:socket(),
            non_neg_integer(),
@@ -36,8 +55,25 @@ send(Socket, WindowSizeIncrement, StreamId) ->
                        <<4:24,?WINDOW_UPDATE:8,0:8,0:1,StreamId:31>>,
                        <<0:1,WindowSizeIncrement:31>>]).
 
--spec to_binary(window_update()) -> iodata().
+
+-spec size_increment(payload()) -> non_neg_integer().
+size_increment(#window_update{window_size_increment=WSI}) ->
+    WSI.
+
+-spec to_binary(payload()) -> iodata().
 to_binary(#window_update{
         window_size_increment=I
     }) ->
     <<0:1,I:31>>.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+read_binary_zero_test() ->
+    ?assertEqual({error, 0, ?PROTOCOL_ERROR, <<>>},
+                 read_binary(<<0:1,0:31>>, #frame_header{stream_id=0,length=4})),
+    ?assertEqual({error, 2, ?PROTOCOL_ERROR, <<>>},
+                 read_binary(<<1:1,0:31>>, #frame_header{stream_id=2,length=4})),
+    ok.
+
+-endif.

--- a/src/http2_frame_window_update.erl
+++ b/src/http2_frame_window_update.erl
@@ -33,6 +33,12 @@ new(Increment) ->
                       Header::frame_header()) ->
                          {ok, payload(), binary()}
                        | {error, stream_id(), error_code(), binary()}.
+read_binary(_,
+            #frame_header{
+               length=L
+               })
+  when L =/= 4 ->
+    {error, 0, ?FRAME_SIZE_ERROR, <<>>};
 read_binary(<<_R:1,0:31,Rem/bits>>, FH) ->
     {error, FH#frame_header.stream_id, ?PROTOCOL_ERROR, Rem};
 read_binary(Bin, #frame_header{length=4}) ->

--- a/test/client_server_SUITE.erl
+++ b/test/client_server_SUITE.erl
@@ -176,7 +176,8 @@ echo_body(_Config) ->
                       flags=?FLAG_END_HEADERS,
                       stream_id=3
                      },
-                   #headers{block_fragment=HeadersBin}},
+                   http2_frame_headers:new(HeadersBin)
+                  },
 
     http2c:send_unaltered_frames(Client, [HeaderFrame]),
 
@@ -188,7 +189,9 @@ echo_body(_Config) ->
     Frames = http2c:get_frames(Client, 3),
     DataFrames = lists:filter(fun({#frame_header{type=?DATA}, _}) -> true;
                                  (_) -> false end, Frames),
-    ResponseData = lists:map(fun({_, #data{data=Data}}) -> Data end, DataFrames),
+    ResponseData = lists:map(fun({_, DataP}) ->
+                                     http2_frame_data:data(DataP)
+                             end, DataFrames),
     io:format("Body: ~p, response: ~p~n", [Body, ResponseData]),
     ?assertEqual(Body, iolist_to_binary(ResponseData)),
     ok.

--- a/test/http2_spec_4_3_SUITE.erl
+++ b/test/http2_spec_4_3_SUITE.erl
@@ -30,6 +30,7 @@ sends_invalid_header_block_fragment(_Config) ->
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
     ct:pal("Resp: ~p", [Resp]),
     ?assertEqual(1, length(Resp)),
-    [{_GoAwayH, GoAway}] = Resp,
-    ?COMPRESSION_ERROR = GoAway#goaway.error_code,
+    [{GoAwayH, GoAway}] = Resp,
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?COMPRESSION_ERROR, http2_frame_goaway:error_code(GoAway)),
     ok.

--- a/test/http2_spec_6_1_SUITE.erl
+++ b/test/http2_spec_6_1_SUITE.erl
@@ -40,9 +40,7 @@ sends_data_with_invalid_pad_length(_Config) ->
          stream_id=1,
          flags=?FLAG_END_HEADERS bor ?FLAG_PADDED
         },
-      #headers{
-         block_fragment=HeadersBin
-        }
+      http2_frame_headers:new(HeadersBin)
      },
 
     http2c:send_unaltered_frames(Client, [HF]),
@@ -54,6 +52,7 @@ sends_data_with_invalid_pad_length(_Config) ->
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
     ct:pal("Resp: ~p", [Resp]),
     ?assertEqual(1, length(Resp)),
-    [{_Header, Payload}] = Resp,
-    ?PROTOCOL_ERROR = Payload#goaway.error_code,
+    [{GoAwayH, GoAway}] = Resp,
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?PROTOCOL_ERROR, http2_frame_goaway:error_code(GoAway)),
     ok.

--- a/test/http2_spec_6_2_SUITE.erl
+++ b/test/http2_spec_6_2_SUITE.erl
@@ -43,17 +43,16 @@ sends_header_with_invalid_pad_length(_Config) ->
          stream_id=1,
          flags=?FLAG_END_HEADERS bor ?FLAG_PADDED
         },
-      #headers{
-         block_fragment=PaddedBin
-        }
+      http2_frame_headers:new(PaddedBin)
      },
     http2c:send_unaltered_frames(Client, [F]),
 
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
     ct:pal("Resp: ~p", [Resp]),
     ?assertEqual(1, length(Resp)),
-    [{_Header, Payload}] = Resp,
-    ?PROTOCOL_ERROR = Payload#goaway.error_code,
+    [{GoAwayH, GoAway}] = Resp,
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?PROTOCOL_ERROR, http2_frame_goaway:error_code(GoAway)),
     ok.
 
 sends_go_example(_Config) ->
@@ -83,7 +82,7 @@ sends_go_example(_Config) ->
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
     ct:pal("Resp: ~p", [Resp]),
     ?assertEqual(1, length(Resp)),
-    [{_Header, Payload}] = Resp,
-    ?PROTOCOL_ERROR = Payload#goaway.error_code,
-
+    [{GoAwayH, GoAway}] = Resp,
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?PROTOCOL_ERROR, http2_frame_goaway:error_code(GoAway)),
     ok.

--- a/test/http2_spec_6_4_SUITE.erl
+++ b/test/http2_spec_6_4_SUITE.erl
@@ -25,9 +25,7 @@ sends_rst_stream_to_idle(_Config) ->
       #frame_header{
          stream_id=1
         },
-      #rst_stream{
-         error_code=?CANCEL
-        }
+      http2_frame_rst_stream:new(?CANCEL)
      },
 
     http2c:send_unaltered_frames(Client, [F]),
@@ -35,6 +33,7 @@ sends_rst_stream_to_idle(_Config) ->
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
     ct:pal("Resp: ~p", [Resp]),
     ?assertEqual(1, length(Resp)),
-    [{_Header, Payload}] = Resp,
-    ?PROTOCOL_ERROR = Payload#goaway.error_code,
+    [{GoAwayH, GoAway}] = Resp,
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?PROTOCOL_ERROR, http2_frame_goaway:error_code(GoAway)),
     ok.

--- a/test/http2_spec_6_5_SUITE.erl
+++ b/test/http2_spec_6_5_SUITE.erl
@@ -32,8 +32,9 @@ sends_invalid_push_setting(_Config) ->
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
     ct:pal("Resp: ~p", [Resp]),
     ?assertEqual(1, length(Resp)),
-    [{_GoAwayH, GoAway}] = Resp,
-    ?PROTOCOL_ERROR = GoAway#goaway.error_code,
+    [{GoAwayH, GoAway}] = Resp,
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?PROTOCOL_ERROR, http2_frame_goaway:error_code(GoAway)),
     ok.
 
 sends_value_above_max_flow_control_window_size(_Config) ->
@@ -45,8 +46,9 @@ sends_value_above_max_flow_control_window_size(_Config) ->
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
     ct:pal("Resp: ~p", [Resp]),
     ?assertEqual(1, length(Resp)),
-    [{_GoAwayH, GoAway}] = Resp,
-    ?FLOW_CONTROL_ERROR = GoAway#goaway.error_code,
+    [{GoAwayH, GoAway}] = Resp,
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?FLOW_CONTROL_ERROR, http2_frame_goaway:error_code(GoAway)),
     ok.
 
 sends_max_frame_size_too_small(_Config) ->
@@ -58,8 +60,9 @@ sends_max_frame_size_too_small(_Config) ->
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
     ct:pal("Resp: ~p", [Resp]),
     ?assertEqual(1, length(Resp)),
-    [{_GoAwayH, GoAway}] = Resp,
-    ?PROTOCOL_ERROR = GoAway#goaway.error_code,
+    [{GoAwayH, GoAway}] = Resp,
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?PROTOCOL_ERROR, http2_frame_goaway:error_code(GoAway)),
     ok.
 
 sends_max_frame_size_too_big(_Config) ->
@@ -71,6 +74,7 @@ sends_max_frame_size_too_big(_Config) ->
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
     ct:pal("Resp: ~p", [Resp]),
     ?assertEqual(1, length(Resp)),
-    [{_GoAwayH, GoAway}] = Resp,
-    ?PROTOCOL_ERROR = GoAway#goaway.error_code,
+    [{GoAwayH, GoAway}] = Resp,
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?PROTOCOL_ERROR, http2_frame_goaway:error_code(GoAway)),
     ok.

--- a/test/http2c.erl
+++ b/test/http2c.erl
@@ -3,7 +3,7 @@
 %% PLEASE ONLY USE FOR TESTING
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+-compile({parse_transform, lager_transform}).
 -module(http2c).
 
 -behaviour(gen_server).
@@ -41,7 +41,7 @@
           send_settings = #settings{} :: settings(),
           encode_context = hpack:new_context() :: hpack:context(),
           next_available_stream_id = 1 :: pos_integer(),
-          incoming_frames = [] :: [frame()],
+          incoming_frames = [] :: [http2_frame:frame()],
           working_frame_header = undefined :: undefined | frame_header(),
           working_frame_payload = <<>> :: binary(),
           working_length = 0 :: non_neg_integer()
@@ -68,7 +68,7 @@ send_binary(Pid, Binary) ->
 %% desgined for testing error conditions by giving you the freedom to
 %% create bad sets of frames. This will problably only be exported
 %% ifdef(TEST)
--spec send_unaltered_frames(pid(), [frame()]) -> ok.
+-spec send_unaltered_frames(pid(), [http2_frame:frame()]) -> ok.
 send_unaltered_frames(Pid, Frames) ->
     [ send_binary(Pid, http2_frame:to_binary(F)) || F <- Frames],
     ok.
@@ -251,7 +251,7 @@ code_change(_OldVsn, State, _Extra) ->
     binary(),
     frame_header() | undefined,
     binary(),
-    [frame()]) -> {[frame()], frame_header() | undefined, binary() | undefined}.
+    [http2_frame:frame()]) -> {[http2_frame:frame()], frame_header() | undefined, binary() | undefined}.
 %%OMG probably a monad
 process_binary(<<>>, undefined, <<>>, Frames) -> {Frames, undefined, <<>>};
 

--- a/test/protocol_errors_SUITE.erl
+++ b/test/protocol_errors_SUITE.erl
@@ -26,42 +26,49 @@ end_per_testcase(_, Config) ->
     ok.
 
 no_data_frame_on_zero(Config) ->
-    one_frame({#frame_header{length=2,type=?DATA,stream_id=0}, #data{data = <<1,2>>}}, Config).
+    one_frame({#frame_header{length=2,type=?DATA,stream_id=0},
+               http2_frame_data:new(<<1,2>>)}, Config).
 
 no_headers_frame_on_zero(Config) ->
-    one_frame({#frame_header{length=2,type=?HEADERS,stream_id=0}, #headers{block_fragment = <<1,2>>}}, Config).
+    one_frame({#frame_header{length=2,type=?HEADERS,stream_id=0},
+               http2_frame_headers:new(<<1,2>>)}, Config).
 
 no_priority_frame_on_zero(Config) ->
-    one_frame({#frame_header{length=5,type=?PRIORITY,stream_id=0}, #priority{exclusive=0, stream_id=1, weight=1}}, Config).
+    one_frame({#frame_header{length=5,type=?PRIORITY,stream_id=0},
+               http2_frame_priority:new(0, 1, 1)}, Config).
 
 no_rst_stream_frame_on_zero(Config) ->
-    one_frame({#frame_header{length=4,type=?RST_STREAM,stream_id=0}, #rst_stream{error_code=?PROTOCOL_ERROR}}, Config).
+    one_frame({#frame_header{length=4,type=?RST_STREAM,stream_id=0},
+               http2_frame_rst_stream:new(?PROTOCOL_ERROR)}, Config).
 
 no_push_promise_frame_on_zero(Config) ->
-    one_frame({#frame_header{length=2,type=?PUSH_PROMISE,stream_id=0}, #push_promise{promised_stream_id=100, block_fragment = <<1,2>>}}, Config).
+    one_frame({#frame_header{length=2,type=?PUSH_PROMISE,stream_id=0},
+               http2_frame_push_promise:new(100, <<1,2>>)}, Config).
 
 no_continuation_frame_on_zero(Config) ->
-    one_frame({#frame_header{length=2,type=?CONTINUATION,stream_id=0}, #continuation{block_fragment = <<1,2>>}}, Config).
+    one_frame({#frame_header{length=2,type=?CONTINUATION,stream_id=0},
+               http2_frame_continuation:new(<<1,2>>)}, Config).
 
 no_settings_frame_on_non_zero(Config) ->
-    one_frame({#frame_header{length=0,type=?SETTINGS,stream_id=1}, #settings{max_concurrent_streams=2, max_header_list_size=1024}}, Config).
+    one_frame({#frame_header{length=0,type=?SETTINGS,stream_id=1},
+               #settings{max_concurrent_streams=2, max_header_list_size=1024}}, Config).
 
 no_ping_frame_on_non_zero(Config) ->
-    one_frame({#frame_header{length=8,type=?PING,stream_id=1}, #ping{opaque_data = <<1:64>>}}, Config).
+    one_frame({#frame_header{length=8,type=?PING,stream_id=1},
+               http2_frame_ping:new(<<1:64>>)}, Config).
 
 no_goaway_frame_on_non_zero(Config) ->
-    one_frame({#frame_header{length=4,type=?GOAWAY,stream_id=1}, #goaway{last_stream_id=1,error_code = ?PROTOCOL_ERROR}}, Config).
+    one_frame({#frame_header{length=4,type=?GOAWAY,stream_id=1},
+               http2_frame_goaway:new(5, ?PROTOCOL_ERROR)}, Config).
 
 
 one_frame(Frame, _Config) ->
     {ok, Client} = http2c:start_link(),
     http2c:send_unaltered_frames(Client, [Frame]),
-
     Resp = http2c:wait_for_n_frames(Client, 0, 1),
-
     ct:pal("Resp: ~p", [Resp]),
-
     ?assertEqual(1, length(Resp)),
-    [{_GoAwayH, GoAway}] = Resp,
-    ?PROTOCOL_ERROR = GoAway#goaway.error_code,
+    [{GoAwayH, GoAway}] = Resp,
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?PROTOCOL_ERROR, http2_frame_goaway:error_code(GoAway)),
     ok.

--- a/test/settings_handshake_SUITE.erl
+++ b/test/settings_handshake_SUITE.erl
@@ -60,12 +60,10 @@ times_out_on_no_ack_of_server_settings(Config) ->
     %% Since we never send our ack, we should get a settings timeout in 5000ms
     ct:pal("waiting for timeout, should arrive in 5000ms"),
     {ok, GoAwayBin} = Transport:recv(Socket, 0, 6000),
-
     ct:pal("GoAwayBin: ~p", [GoAwayBin]),
-    [{FH, GoAway}] = http2_frame:from_binary(GoAwayBin),
-    ct:pal("Type: ~p", [FH#frame_header.type]),
-    ?GOAWAY = FH#frame_header.type,
-    ?SETTINGS_TIMEOUT = GoAway#goaway.error_code,
+    [{GoAwayH, GoAway}] = http2_frame:from_binary(GoAwayBin),
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?SETTINGS_TIMEOUT, http2_frame_goaway:error_code(GoAway)),
     ok.
 
 protocol_error_on_never_send_client_settings(Config) ->
@@ -99,11 +97,9 @@ protocol_error_on_never_send_client_settings(Config) ->
     {ok, GoAwayBin} = Transport:recv(Socket, 0, 6000),
 
     ct:pal("GoAwayBin: ~p", [GoAwayBin]),
-    [{FH, GoAway}] = http2_frame:from_binary(GoAwayBin),
-    ct:pal("Type: ~p", [FH#frame_header.type]),
-    ?GOAWAY = FH#frame_header.type,
-    ct:pal("Error code: ~p", [GoAway#goaway.error_code]),
-    ?SETTINGS_TIMEOUT = GoAway#goaway.error_code,
+    [{GoAwayH, GoAway}] = http2_frame:from_binary(GoAwayBin),
+    ?assertEqual(?GOAWAY, GoAwayH#frame_header.type),
+    ?assertEqual(?SETTINGS_TIMEOUT, http2_frame_goaway:error_code(GoAway)),
     ok.
 
 default_setting_honored_before_ack(_Config) ->


### PR DESCRIPTION
OOOF! This is a big one, but fortunately it's mostly repetitive.

In an effort to make things easier to follow, and to protect the payload records, I've moved them all out of `http2.hrl` and into their own respective modules, with the exception of `#settings{}` which needs to get handled differently, and so was scoped out of this change.

Since we were really only ever using the frame records to bind specific variables on pattern match, I created "getters" for that purpose, with the goal of eventually only using pattern matches in function clauses (e.g. `route_frame`) for choosing the clause to run, not bindings.

I also improved the error tuple reporting for `http2_frame` which will now allow us to `GOAWAY` or `RST_STREAM` on certain errors in frame reading and validation without depending on `http2_connection:route_frame`, which will ultimately make that function less complicated.