### PR TITLE
Allow send_h from open stream state

### DIFF
--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -5,7 +5,7 @@
 -export([
          start_link/4,
          send_pp/2,
-         send_frame/2,
+         send_data/2,
          stream_id/0,
          connection/0,
          send_window_update/1,
@@ -114,10 +114,10 @@ start_link(StreamId, Connection, CallbackModule, Socket) ->
 send_pp(Pid, Headers) ->
     gen_fsm:send_event(Pid, {send_pp, Headers}).
 
--spec send_frame(pid(), http2_frame:frame()) ->
+-spec send_data(pid(), http2_frame:frame()) ->
                         ok | flow_control.
-send_frame(Pid, Frame) ->
-    gen_fsm:send_event(Pid, {send_frame, Frame}).
+send_data(Pid, Frame) ->
+    gen_fsm:send_event(Pid, {send_data, Frame}).
 
 -spec stream_id() -> stream_id().
 stream_id() ->
@@ -345,7 +345,7 @@ open({recv_h, Trailers},
         {error, Code} ->
             rst_stream_(Code, Stream)
     end;
-open({send_frame,
+open({send_data,
       {#frame_header{
           type=?DATA,
           flags=Flags
@@ -363,6 +363,14 @@ open({send_frame,
                 open
         end,
     {next_state, NextState, Stream};
+open(
+  {send_h, Headers},
+  #stream_state{}=Stream) ->
+    {next_state,
+     open,
+     Stream#stream_state{
+       response_headers=Headers
+      }};
 open(Msg, Stream) ->
     lager:warning("Some unexpected message in open state. ~p, ~p", [Msg, Stream]),
     {next_state, open, Stream}.
@@ -376,7 +384,7 @@ half_closed_remote(
        response_headers=Headers
       }};
 half_closed_remote(
-                  {send_frame,
+                  {send_data,
                    {
                      #frame_header{
                         flags=Flags,

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -114,6 +114,7 @@ start_link(StreamId, Connection, CallbackModule, Socket) ->
 send_pp(Pid, Headers) ->
     gen_fsm:send_event(Pid, {send_pp, Headers}).
 
+%% This can only send data frames
 -spec send_data(pid(), http2_frame:frame()) ->
                         ok | flow_control.
 send_data(Pid, Frame) ->

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -734,7 +734,7 @@ s_send_what_we_can(SWS, MFS, #active_stream{}=Stream) ->
                    send_window_size=SSWS-MaxToSend}}
         end,
 
-    _Sent = h2_stream:send_frame(Stream#active_stream.pid, Frame),
+    _Sent = h2_stream:send_data(Stream#active_stream.pid, Frame),
 
     case ExitStrategy of
         max_frame_size ->


### PR DESCRIPTION
Fixes 

```
12:15:10.317 [warning] Some unexpected message in open state. {send_h,[{<<":status">>,<<"400">>}]}, {stream_state,1,<0.399.0>,{ssl,{sslsocket,{gen_tcp,#Port<0.88376>,tls_connection,<0.376.0>},<0.397.0>}},idle,...
```