### PR TITLE
Fixed a fatal flaw in flow control math

### DIFF
--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -482,10 +482,11 @@ route_frame(F={H=#frame_header{
     lager:debug("[~p] Received DATA Frame for Stream ~p",
                 [Conn#connection.type, StreamId]),
     Stream = h2_stream_set:get(StreamId, Streams),
+
     case h2_stream_set:type(Stream) of
         active ->
             case {
-              h2_stream_set:recv_window_size(Stream) =< L,
+              h2_stream_set:recv_window_size(Stream) < L,
               Conn#connection.flow_control,
               L > 0
              } of
@@ -506,20 +507,22 @@ route_frame(F={H=#frame_header{
                                [Conn#connection.type, StreamId, L]),
                     h2_frame_window_update:send(Conn#connection.socket,
                                                 L, StreamId),
-                    send_window_update(self(), L);
+                    send_window_update(self(), L),
+                    recv_data(Stream, F),
+                    {next_state,
+                     connected,
+                     Conn};
                 _Tried ->
-                    ok
-            end,
-            recv_data(Stream, F),
-
-            {next_state,
-             connected,
-             Conn#connection{
-               recv_window_size=CRWS-L,
-               streams=h2_stream_set:upsert(
-                         h2_stream_set:decrement_recv_window(L, Stream),
-                         Streams)
-              }};
+                    recv_data(Stream, F),
+                    {next_state,
+                     connected,
+                     Conn#connection{
+                       recv_window_size=CRWS-L,
+                       streams=h2_stream_set:upsert(
+                                 h2_stream_set:decrement_recv_window(L, Stream),
+                                 Streams)
+                      }}
+            end;
         _ ->
             go_away(?PROTOCOL_ERROR, Conn)
     end;
@@ -772,7 +775,6 @@ route_frame(
     WSI = h2_frame_window_update:size_increment(Payload),
     lager:debug("[~p] Received WINDOW_UPDATE Frame for Stream ~p",
                 [Conn#connection.type, StreamId]),
-
     Stream = h2_stream_set:get(StreamId, Streams),
     case h2_stream_set:type(Stream) of
         idle ->

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -501,6 +501,10 @@ route_frame(F={H=#frame_header{
                     rst_stream(Stream,
                                ?FLOW_CONTROL_ERROR,
                                Conn);
+                %% If flow control is set to auto, and L > 0, send
+                %% window updates back to the peer. If L == 0, we're
+                %% not allowed to send window_updates of size 0, so we
+                %% hit the next clause
                 {false, auto, true} ->
                     %% Make window size great again
                     lager:info("[~p] Stream ~p WindowUpdate ~p",
@@ -512,6 +516,9 @@ route_frame(F={H=#frame_header{
                     {next_state,
                      connected,
                      Conn};
+                %% Either
+                %% {false, auto, true} or
+                %% {false, manual, _DoesntMatter}
                 _Tried ->
                     recv_data(Stream, F),
                     {next_state,

--- a/test/flow_control_SUITE.erl
+++ b/test/flow_control_SUITE.erl
@@ -23,7 +23,7 @@ init_per_testcase(
     PreChatterConfig =
         [
          {stream_callback_mod, server_connection_receive_window},
-         {initial_window_size, 64},
+         {initial_window_size, ?DEFAULT_INITIAL_WINDOW_SIZE * 2},
          {flow_control, manual}
         |Config],
     chatterbox_test_buddy:start(PreChatterConfig);


### PR DESCRIPTION
The first problem was a case clause that was calling rst_stream/3, but
not being the return of the function. So the connection state never got
the memo that the stream was reset.

Also there was a problem with automatic flow control math. The problem
is simple to explain.

Say your stream's initial flow control window is 65K. It's a fair
assumption, since that's the default. Say we send that stream a frame
that's 16K. Also a default size. Since we're calculating flow control
windows, the new window size would be 65K - 16K = 49K. Great. But with
automatic flow control, we're immediately sending a WINDOW_UPDATE of
16K. This tells the sender that we're willing to receive 65K again, but
on the receiving side, we weren't incrementing the window, so we stayed
at 49K. Every frame would just lower what we thought we could recieve,
but cause no change on the client side.