### PR TITLE
Change Transport:setopts/2 calls to sock:setopts/2

### DIFF
--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -131,7 +131,7 @@ become(Socket) ->
 
 -spec become(socket(), settings()) -> no_return().
 become({Transport, Socket}, Http2Settings) ->
-    ok = Transport:setopts(Socket, [{packet, raw}, binary]),
+    ok = sock:setopts({Transport, Socket}, [{packet, raw}, binary]),
     {_, _, NewState} =
         start_http2_server(Http2Settings,
                            #connection{
@@ -146,7 +146,7 @@ become({Transport, Socket}, Http2Settings) ->
 %% Init callback
 init({client, Transport, Host, Port, SSLOptions, Http2Settings}) ->
     {ok, Socket} = Transport:connect(Host, Port, client_options(Transport, SSLOptions)),
-    ok = Transport:setopts(Socket, [{packet, raw}, binary]),
+    ok = sock:setopts({Transport, Socket}, [{packet, raw}, binary]),
     Transport:send(Socket, <<?PREFACE>>),
     InitialState =
         #connection{


### PR DESCRIPTION
### Summary

Calling `h2_client:start_link/3` with a transport type of `http` causes a crash.

### Details

- A call is made to `Transport:setopts(Socket, [{packet, raw}, binary])`. `Transport` can be either `ssl` or `gen_tcp`.
- When the transport type is `http`, `Transport = gen_tcp`, so the call is made to `gen_tcp:setopts/2`.
- `gen_tcp:setopts/2` does not exist, so there is a crash.

### Suggested Fix

Changing the call to `sock:setopts({Transport, Socket},  [{packet, raw}, binary])` seems to fix the issue, although it isn't certain that this is the appropriate fix, so feel free to ignore the pull request.

### To reproduce the issue

~~~ erlang
6> {ok, Pid} = h2_client:start_link(http, "localhost", 80).
** exception exit: undef
     in function  gen_tcp:setopts/2
        called as gen_tcp:setopts(#Port<0.55325>,[{packet,raw},binary])
~~~