### PR TITLE
Fix setopts and response body

### DIFF
--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -131,7 +131,7 @@ become(Socket) ->
 
 -spec become(socket(), settings()) -> no_return().
 become({Transport, Socket}, Http2Settings) ->
-    ok = Transport:setopts(Socket, [{packet, raw}, binary]),
+    ok = sock:setopts({Transport, Socket}, [{packet, raw}, binary]),
     {_, _, NewState} =
         start_http2_server(Http2Settings,
                            #connection{
@@ -146,7 +146,7 @@ become({Transport, Socket}, Http2Settings) ->
 %% Init callback
 init({client, Transport, Host, Port, SSLOptions, Http2Settings}) ->
     {ok, Socket} = Transport:connect(Host, Port, client_options(Transport, SSLOptions)),
-    ok = Transport:setopts(Socket, [{packet, raw}, binary]),
+    ok = sock:setopts({Transport, Socket}, [{packet, raw}, binary]),
     Transport:send(Socket, <<?PREFACE>>),
     InitialState =
         #connection{

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -437,7 +437,6 @@ half_closed_local(
      incoming_frames=IFQ
      } = Stream) ->
     NewQ = queue:in(F, IFQ),
-
     case ?IS_FLAG(Flags, ?FLAG_END_STREAM) of
         true ->
             Data =
@@ -455,6 +454,18 @@ half_closed_local(
                incoming_frames=NewQ
               }}
     end;
+
+half_closed_local(recv_es,
+                  #stream_state{
+                     response_body = undefined,
+                     incoming_frames = Q
+                    } = Stream) ->
+    Data = [h2_frame_data:data(Payload) || {#frame_header{type=?DATA}, Payload} <- queue:to_list(Q)],
+    {next_state, closed,
+     Stream#stream_state{
+       incoming_frames=queue:new(),
+       response_body = Data
+      }, 0};
 
 half_closed_local(recv_es,
                   #stream_state{


### PR DESCRIPTION
This PR contains two fixes:
- fix `setopts`;
- fix populating `response_data` when `END_STREAM` flag is sent seperately from data.