### PR TITLE
Add support for getting peer cert when using TLS

### DIFF
--- a/src/sock.erl
+++ b/src/sock.erl
@@ -14,6 +14,7 @@
          recv/3,
          close/1,
          peername/1,
+         peercert/1,
          setopts/2
         ]).
 
@@ -60,6 +61,11 @@ peername({ssl, Socket}) ->
     ssl:peername(Socket);
 peername({gen_tcp, Socket}) ->
     inet:peername(Socket).
+
+peercert({ssl, Socket}) ->
+    ssl:peercert(Socket);
+peercert({gen_tcp, _Socket}) ->
+    {error, unsupported}.
 
 setopts({ssl, Socket}, Opts) ->
     ssl:setopts(Socket, Opts);


### PR DESCRIPTION
Checking a peer's TLS certificate is important in my server application. I looked for a way to do this without changing chatterbox code, but couldn't figure one out, so in the spirit of `get_peer/1`, I added `sock:peercert/1` and `h2_connection:get_peercert/1`.