### PR TITLE
support bidirectional streams

### DIFF
--- a/src/chatterbox_static_stream.erl
+++ b/src/chatterbox_static_stream.erl
@@ -9,6 +9,7 @@
          on_receive_request_headers/2,
          on_send_push_promise/2,
          on_receive_request_data/2,
+         on_receive_response_data/2,
          on_request_end_stream/1
         ]).
 
@@ -33,6 +34,10 @@ on_send_push_promise(Headers, State) ->
 
 on_receive_request_data(Bin, State)->
     lager:info("on_receive_request_data(~p, ~p)", [Bin, State]),
+    {ok, State}.
+
+on_receive_response_data(Bin, State)->
+    lager:info("on_receive_response_data(~p, ~p)", [Bin, State]),
     {ok, State}.
 
 on_request_end_stream(State=#cb_static{connection_pid=ConnPid,

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -943,7 +943,7 @@ handle_event({send_body, StreamId, Body, Opts},
              #connection{}=Conn) ->
     lager:debug("[~p] Send Body Stream ~p",
                 [Conn#connection.type, StreamId]),
-    BodyComplete = proplists:get_value(send_end_stream, Opts, true),
+    BodyComplete = proplists:get_value(send_end_stream, Opts, false),
 
     Stream = h2_stream_set:get(StreamId, Conn#connection.streams),
     case h2_stream_set:type(Stream) of

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -3,7 +3,7 @@
 
 %% Public API
 -export([
-         start_link/4,
+         start_link/5,
          send_pp/2,
          send_data/2,
          stream_id/0,
@@ -46,6 +46,7 @@
 
 -record(stream_state, {
           stream_id = undefined :: stream_id(),
+          type = undefined :: client | server,
           connection = undefined :: undefined | pid(),
           socket = undefined :: sock:socket(),
           state = idle :: stream_state_name(),
@@ -96,14 +97,16 @@
 %% Public API
 -spec start_link(
         StreamId :: stream_id(),
+        server | client,
         Connection :: pid(),
         CallbackModule :: module(),
         Socket :: sock:socket()
                   ) ->
                         {ok, pid()} | ignore | {error, term()}.
-start_link(StreamId, Connection, CallbackModule, Socket) ->
+start_link(StreamId, Type, Connection, CallbackModule, Socket) ->
     gen_fsm:start_link(?MODULE,
                        [StreamId,
+                        Type,
                         Connection,
                         CallbackModule,
                         Socket],
@@ -144,6 +147,7 @@ stop(Pid) ->
 
 init([
       StreamId,
+      Type,
       ConnectionPid,
       CB,
       Socket
@@ -155,6 +159,7 @@ init([
                   callback_mod=CB,
                   socket=Socket,
                   stream_id=StreamId,
+                  type=Type,
                   connection=ConnectionPid,
                   callback_state=CallbackState
                  }}.
@@ -282,13 +287,14 @@ open({recv_data,
           type=?DATA
          }, Payload}=F},
      #stream_state{
+        type=Type,
         incoming_frames=IFQ,
         callback_mod=CB,
         callback_state=CallbackState
        }=Stream)
   when ?NOT_FLAG(Flags, ?FLAG_END_STREAM) ->
     Bin = h2_frame_data:data(Payload),
-    {ok, NewCBState} = CB:on_receive_request_data(Bin, CallbackState),
+    {ok, NewCBState} = handle_data(Type, CB, Bin, CallbackState),
     {next_state,
      open,
      Stream#stream_state{
@@ -307,11 +313,12 @@ open({recv_data,
      #stream_state{
         incoming_frames=IFQ,
         callback_mod=CB,
+        type=Type,
         callback_state=CallbackState
        }=Stream)
   when ?IS_FLAG(Flags, ?FLAG_END_STREAM) ->
     Bin = h2_frame_data:data(Payload),
-    {ok, CallbackState1} = CB:on_receive_request_data(Bin, CallbackState),
+    {ok, CallbackState1} = handle_data(Type, CB, Bin, CallbackState),
     NewStream = Stream#stream_state{
                   incoming_frames=queue:in(F, IFQ),
                   request_body_size=Stream#stream_state.request_body_size+L,
@@ -319,6 +326,10 @@ open({recv_data,
                   callback_state=CallbackState1
                  },
     case check_content_length(NewStream) of
+        undefined ->
+            {next_state,
+             open,
+             NewStream};
         ok ->
             {ok, NewCBState} = CB:on_request_end_stream(CallbackState1),
             {next_state,
@@ -334,7 +345,7 @@ open({recv_data,
 
 %% Trailers
 open({recv_h, Trailers},
-     #stream_state{}=Stream) ->
+     #stream_state{type=server}=Stream) ->
     case is_valid_headers(request, Trailers) of
         ok ->
             {next_state,
@@ -345,6 +356,19 @@ open({recv_h, Trailers},
         {error, Code} ->
             rst_stream_(Code, Stream)
     end;
+open({recv_h, Headers},
+     #stream_state{type=client}=Stream) ->
+    case is_valid_headers(response, Headers) of
+        ok ->
+            {next_state,
+             open,
+             Stream#stream_state{
+               response_headers=Headers
+              }};
+        {error, Code} ->
+            rst_stream_(Code, Stream)
+    end;
+
 open({send_data,
       {#frame_header{
           type=?DATA,
@@ -567,7 +591,7 @@ check_content_length(Stream) ->
 
     case ContentLength of
         undefined ->
-            ok;
+            undefined;
         _Other ->
             try binary_to_integer(ContentLength) of
                 Integer ->
@@ -656,3 +680,8 @@ validate_pseudos(_, DoneWithPseudos, _Found) ->
       DoneWithPseudos)
         andalso
         no_upper_names(DoneWithPseudos).
+
+handle_data(server, CB, Bin, CallbackState) ->
+    CB:on_receive_request_data(Bin, CallbackState);
+handle_data(client, CB, Bin, CallbackState) ->
+    CB:on_receive_response_data(Bin, CallbackState).

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -90,6 +90,11 @@
             CallbackState :: callback_state())->
     {ok, NewState :: callback_state()}.
 
+-callback on_receive_response_data(
+            iodata(),
+            CallbackState :: callback_state())->
+    {ok, NewState :: callback_state()}.
+
 -callback on_request_end_stream(
             CallbackState :: callback_state()) ->
     {ok, NewState :: callback_state()}.

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -225,6 +225,7 @@ new_stream(
         false ->
             {ok, Pid} = h2_stream:start_link(
                        StreamId,
+                       StreamSet#stream_set.type,
                        self(),
                        CBMod,
                        Socket

--- a/test/double_body_handler.erl
+++ b/test/double_body_handler.erl
@@ -9,6 +9,7 @@
          on_receive_request_headers/2,
          on_send_push_promise/2,
          on_receive_request_data/2,
+         on_receive_response_data/2,
          on_request_end_stream/1
         ]).
 
@@ -34,6 +35,9 @@ on_send_push_promise(_Headers, State) -> {ok, State}.
             iodata(),
             CallbackState :: any())-> {ok, NewState :: any()}.
 on_receive_request_data(_Data, State) -> {ok, State}.
+
+on_receive_response_data(_Bin, State)->
+    {ok, State}.
 
 -spec on_request_end_stream(
             CallbackState :: any()) ->

--- a/test/echo_handler.erl
+++ b/test/echo_handler.erl
@@ -9,6 +9,7 @@
          on_receive_request_headers/2,
          on_send_push_promise/2,
          on_receive_request_data/2,
+         on_receive_response_data/2,
          on_request_end_stream/1
         ]).
 
@@ -36,6 +37,9 @@ on_send_push_promise(_Headers, State) -> {ok, State}.
             CallbackState :: any())-> {ok, NewState :: any()}.
 on_receive_request_data(Data, State=#state{buffer=Buffer}) ->
     {ok, State#state{buffer = <<Buffer/binary, Data/binary>>}}.
+
+on_receive_response_data(_Bin, State)->
+    {ok, State}.
 
 -spec on_request_end_stream(
             CallbackState :: any()) ->

--- a/test/flow_control_handler.erl
+++ b/test/flow_control_handler.erl
@@ -11,6 +11,7 @@
          on_receive_request_headers/2,
          on_send_push_promise/2,
          on_receive_request_data/2,
+         on_receive_response_data/2,
          on_request_end_stream/1
         ]).
 
@@ -37,6 +38,9 @@ on_send_push_promise(_Headers, State) -> {ok, State}.
             iodata(),
             CallbackState :: any())-> {ok, NewState :: any()}.
 on_receive_request_data(_Data, State) -> {ok, State}.
+
+on_receive_response_data(_Bin, State)->
+    {ok, State}.
 
 -spec on_request_end_stream(
             CallbackState :: any()) ->

--- a/test/peer_test_handler.erl
+++ b/test/peer_test_handler.erl
@@ -9,6 +9,7 @@
          on_receive_request_headers/2,
          on_send_push_promise/2,
          on_receive_request_data/2,
+         on_receive_response_data/2,
          on_request_end_stream/1
         ]).
 
@@ -38,6 +39,9 @@ on_send_push_promise(_Headers, State) -> {ok, State}.
             iodata(),
             CallbackState :: any())-> {ok, NewState :: any()}.
 on_receive_request_data(_Data, State) -> {ok, State}.
+
+on_receive_response_data(_Bin, State)->
+    {ok, State}.
 
 -spec on_request_end_stream(
             CallbackState :: any()) ->

--- a/test/server_connection_receive_window.erl
+++ b/test/server_connection_receive_window.erl
@@ -7,6 +7,7 @@
          on_receive_request_headers/2,
          on_send_push_promise/2,
          on_receive_request_data/2,
+         on_receive_response_data/2,
          on_request_end_stream/1
         ]).
 
@@ -29,6 +30,10 @@ on_send_push_promise(Headers, State) ->
 
 on_receive_request_data(Bin, State)->
     ct:pal("on_receive_request_data(~p, ~p)", [Bin, State]),
+    {ok, State}.
+
+on_receive_response_data(_Bin, State)->
+    ct:pal("on_receive_response_data(Bin!, ~p)", [State]),
     {ok, State}.
 
 on_request_end_stream(State) ->

--- a/test/server_stream_receive_window.erl
+++ b/test/server_stream_receive_window.erl
@@ -7,6 +7,7 @@
          on_receive_request_headers/2,
          on_send_push_promise/2,
          on_receive_request_data/2,
+         on_receive_response_data/2,
          on_request_end_stream/1
         ]).
 
@@ -29,6 +30,10 @@ on_send_push_promise(Headers, State) ->
 
 on_receive_request_data(_Bin, State)->
     ct:pal("on_receive_request_data(Bin!, ~p)", [State]),
+    {ok, State}.
+
+on_receive_response_data(_Bin, State)->
+    ct:pal("on_receive_response_data(Bin!, ~p)", [State]),
     {ok, State}.
 
 on_request_end_stream(State) ->


### PR DESCRIPTION
This patch adds logic to the stream handler to distinguish between a client and server for headers and data and will allow for clients to handle headers/data before ever sending a body, and staying open along with the server to send data back and forth.

I tested this by creating an echo server with a client that reads from stdin. I'll have to post that later because I did it by hacking it into h2_client, so needs to be separated and cleaned up :)

May resolve @benoitc 's issue https://github.com/joedevivo/chatterbox/issues/73 however an interface for client vs server stream handling likely needs to be created.
