### PR TITLE
Fix check of PING ACK flag

### DIFF
--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -742,7 +742,7 @@ route_frame({H, _Payload},
 route_frame({H, Ping},
             #connection{}=Conn)
     when H#frame_header.type == ?PING,
-         ?NOT_FLAG((#frame_header.flags), ?FLAG_ACK) ->
+         ?NOT_FLAG((H#frame_header.flags), ?FLAG_ACK) ->
     lager:debug("[~p] Received PING",
                [Conn#connection.type]),
     Ack = h2_frame_ping:ack(Ping),


### PR DESCRIPTION
Sending a PING from a chatterbox client to a chatterbox server results
in an infinite PING loop. This is because the check for the PING ACK
flag is incorrect (it is missing the 'H' variable, leading to the ACK
flag being seen always as off).

This commit fixes the bug.