### PR TITLE
Add rebar.config.script deps for rebar2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,11 @@
+case erlang:function_exported(rebar3, main, 1) of
+    true -> % rebar3
+        CONFIG;
+    false -> % rebar 2.x or older
+        %% Rebuild deps, possibly including those that have been moved to
+        %% profiles
+        [{deps, [
+        {lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "3.2.4"}}},
+        {hpack, ".*", {git, "https://github.com/joedevivo/hpack.git", {tag, "0.2.3"}}}
+        ]} | lists:keydelete(deps, 1, CONFIG)]
+end.


### PR DESCRIPTION
I am using `chatterbox` in a `rebar2` project (some "old" application that needs now http2 client).

With this `rebar.config.script` it's possible to include `chatterbox` as a dependency.

thanks 
