### PR TITLE
Improve client side performance

### DIFF
--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1070,13 +1070,19 @@ handle_sync_event(streams, _F, StateName,
 handle_sync_event({get_response, StreamId}, _F, StateName,
                   #connection{}=Conn) ->
     Stream = h2_stream_set:get(StreamId, Conn#connection.streams),
-    Reply = case h2_stream_set:type(Stream) of
-                closed ->
-                    {ok, h2_stream_set:response(Stream)};
-                active ->
-                    not_ready
-            end,
-    {reply, Reply, StateName, Conn};
+    {Reply, NewStreams} =
+        case h2_stream_set:type(Stream) of
+            closed ->
+                NewStreams0 =
+                    h2_stream_set:close(
+                      Stream,
+                      garbage,
+                      Conn#connection.streams),
+                {{ok, h2_stream_set:response(Stream)}, NewStreams0};
+            active ->
+                {not_ready, Conn#connection.streams}
+        end,
+    {reply, Reply, StateName, Conn#connection{streams=NewStreams}};
 handle_sync_event({new_stream, NotifyPid}, _F, StateName,
                   #connection{
                      streams=Streams,


### PR DESCRIPTION
This PR changes `get_response` behaviour so that it removes stream for the peer stream set just after getting the response. Without this change, the http client is unusable under heavy load due to constantly growing stream set (closed streams with responses never get to be clean up). 
  