### PR TITLE
Fix the remaining window size in s_send_what_we_can

### DIFF
--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -745,7 +745,7 @@ s_send_what_we_can(SWS, MFS, #active_stream{}=Stream) ->
         stream ->
             {SWS - SentBytes, NewS};
         connection ->
-            {0, NewS}
+            {SWS - SentBytes, NewS}
     end;
 s_send_what_we_can(SWS, _MFS, NonActiveStream) ->
     {SWS, NonActiveStream}.


### PR DESCRIPTION
I'm not sure why the remaining window size of s_send_what_we_can was set to 0 directly when in the connection strategy. But it seems unreasonable to me.

There another problem: Should we reduce connection window size when in max_frame_size or stream strategy? The HTTP2 spec doesn't mention this.