### PR TITLE
Account for http experimental settings frame codes

### DIFF
--- a/src/h2_frame_settings.erl
+++ b/src/h2_frame_settings.erl
@@ -102,6 +102,11 @@ parse_settings(<<0,5,Val:4/binary,T/binary>>, S) ->
     parse_settings(T, [{?SETTINGS_MAX_FRAME_SIZE, binary:decode_unsigned(Val)}|S]);
 parse_settings(<<0,6,Val:4/binary,T/binary>>, S)->
     parse_settings(T, [{?SETTINGS_MAX_HEADER_LIST_SIZE, binary:decode_unsigned(Val)}|S]);
+% Frame settings in the range 0xf000 and 0xffff are reserved for experimental use. They can
+% be ignored but should not cause parse settings issues.
+parse_settings(<<SettingsCode:2/binary,_:4/binary,T/binary>>, S)
+  when SettingsCode >= 61440; SettingsCode =< 65535 ->
+    parse_settings(T, S); % Ignore settings in the experimental range
 parse_settings(<<>>, Settings) ->
     Settings.
 


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc7540#section-11.3, the http
settings frame parameter with code in the range 0xf000 to 0xffff
is reserved for experimental use.

A specific example is gRPC's "allow true binary metadata" experimental
optimization, which uses code 65027 and throws parse settings errors
with chatterbox.
See: https://github.com/grpc/grpc/blob/master/src/core/ext/transport/chttp2/transport/http2_settings.h#L34

Any http frame settings that is not officially approved or in the experimental range
should throw an error.