### PR TITLE
Fix padded payload reading (and other minor updates)

### DIFF
--- a/src/h2_padding.erl
+++ b/src/h2_padding.erl
@@ -26,8 +26,8 @@ read_possibly_padded_payload(Bin, Header) ->
                          -> binary() | {error, error_code()}.
 read_padded_payload(<<Padding:8,Bytes/bits>>,
                     #frame_header{length=Length}) ->
-    L = Length - Padding,
-    case L > 0 of
+    L = Length - Padding - 1, % Exclude Pad length field (1 byte)
+    case L >= 0 of
         true ->
             <<Data:L/binary,_:Padding/binary>> = Bytes,
             Data;

--- a/test/http2c.erl
+++ b/test/http2c.erl
@@ -142,7 +142,7 @@ init([]) ->
     BinToSend = h2_frame_settings:send(#settings{}, ClientSettings),
     Transport:send(Socket, BinToSend),
 
-    {AH, _PAck} = h2_frame:read({Transport, Socket}, 100),
+    {AH, _PAck} = h2_frame:read({Transport, Socket}, 1000),
     _ = ?IS_FLAG((AH#frame_header.flags), ?FLAG_ACK),
 
     case Transport of


### PR DESCRIPTION
Hi Joe DeVivo,

4 unrelated updates :
- Commit dcdb78e : fix padded payload reading. Bug triggers when you try to connect to google search
- Commit 4655c26 : fix timeout in test
- Commit cf31520 : decode body according to content-encoding (auto uncompress body)
- Commit bdf0ffe/d1d07b8 : factorize start client link code and add a new case