### PR TITLE
Add no link client start

### DIFF
--- a/src/h2_client.erl
+++ b/src/h2_client.erl
@@ -19,6 +19,7 @@
          start_link/2,
          start_link/3,
          start_link/4,
+         start/4,
          start_ssl_upgrade_link/4,
          stop/1,
          send_request/3,
@@ -107,6 +108,20 @@ start_link(Transport, Host, Port, SSLOptions) ->
                https -> ssl
            end,
     h2_connection:start_client_link(NewT, Host, Port, SSLOptions, chatterbox:settings(client)).
+
+-spec start(http | https,
+                 string(),
+                 non_neg_integer(),
+                 [ssl:ssl_option()]) ->
+                        {ok, pid()}
+                      | ignore
+                      | {error, term()}.
+start(Transport, Host, Port, SSLOptions) ->
+    NewT = case Transport of
+               http -> gen_tcp;
+               https -> ssl
+           end,
+    h2_connection:start_client(NewT, Host, Port, SSLOptions, chatterbox:settings(client)).
 
 start_ssl_upgrade_link(Host, Port, InitialMessage, SSLOptions) ->
     h2_connection:start_ssl_upgrade_link(Host, Port, InitialMessage, SSLOptions, chatterbox:settings(client)).

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -4,6 +4,8 @@
 
 %% Start/Stop API
 -export([
+         start_client/2,
+         start_client/5,
          start_client_link/2,
          start_client_link/5,
          start_ssl_upgrade_link/5,
@@ -122,12 +124,29 @@
 start_client_link(Transport, Host, Port, SSLOptions, Http2Settings) ->
     gen_statem:start_link(?MODULE, {client, Transport, Host, Port, SSLOptions, Http2Settings}, []).
 
+-spec start_client(gen_tcp | ssl,
+                        inet:ip_address() | inet:hostname(),
+                        inet:port_number(),
+                        [ssl:ssl_option()],
+                        settings()
+                       ) ->
+                               {ok, pid()} | ignore | {error, term()}.
+start_client(Transport, Host, Port, SSLOptions, Http2Settings) ->
+    gen_statem:start(?MODULE, {client, Transport, Host, Port, SSLOptions, Http2Settings}, []).
+
 -spec start_client_link(socket(),
                         settings()
                        ) ->
                                {ok, pid()} | ignore | {error, term()}.
 start_client_link({Transport, Socket}, Http2Settings) ->
     gen_statem:start_link(?MODULE, {client, {Transport, Socket}, Http2Settings}, []).
+
+-spec start_client(socket(),
+                        settings()
+                       ) ->
+                               {ok, pid()} | ignore | {error, term()}.
+start_client({Transport, Socket}, Http2Settings) ->
+    gen_statem:start(?MODULE, {client, {Transport, Socket}, Http2Settings}, []).
 
 -spec start_ssl_upgrade_link(inet:ip_address() | inet:hostname(),
                              inet:port_number(),


### PR DESCRIPTION
Due to how `supervisor` restarts processes (no backoff), sometimes it's really handy to treat connections as resources, not like part of OTP supervision. 
I'm aware that it's possible to `unlink` but this does not affect anything if the `h2_connection` exits during `init` (which is how `chatterbox` normally does things). I'm also aware, that it's possible to "fix" that by using `trap_exit`, but this has other implications that make it feel more like a hack. 
Thus, this change adds "no link" start to `h2_client` for those that would rather use `erlang:monitor/1` rather then links.